### PR TITLE
Phase out AUTHORS file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,0 @@
-# Lead developer
-
-* Denys Shabalin <[denys.shabalin@epfl.ch](mailto:denys.shabalin@epfl.ch)> [@den_sh](https://twitter.com/den_sh)
-
-# Contributors
-
-* Martynas Mickevičius <[martynas.mickevicius@typesafe.com](mailto:martynas.mickevicius@typesafe.com)> [@mmartynas](https://twitter.com/mmartynas)

--- a/README.md
+++ b/README.md
@@ -111,5 +111,4 @@ not on the top-level (caused by restrictions of macro-annotations.)
    use cases. If you propose a performance enhancement include before & after results of
    corresponding jmh performance benchmark run in the commit message.
 1. Fire up a pull request. Don't forget to sign
-   [Scala CLA](http://typesafe.com/contribute/cla/scala) and add yourself to the
-   [list of contributors](https://github.com/densh/scala-offheap/blob/master/AUTHORS.md).
+   [Scala CLA](http://typesafe.com/contribute/cla/scala).


### PR DESCRIPTION
There seems to be enough information available through Scala CLA to
contact people in case of license changes.