### PR TITLE
Performance and correctness fixes for Arrays

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -12,6 +12,7 @@ final class Array[A] private (val $addr: Addr) extends AnyVal {
   def update(index: Addr, value: A): Unit                = macro macros.Array.update
   def foreach(f: A => Unit): Unit                        = macro macros.Array.foreach
   def map[B](f: A => B)(implicit a: Allocator): Array[B] = macro macros.Array.map[B]
+  def toArray: scala.Array[A]                            = macro macros.Array.toArray
 
   override def toString =
     if ($addr == 0L) s"offheap.x64.Array.empty"
@@ -28,4 +29,5 @@ object Array {
   def empty[T]: Array[T]                                     = new Array[T](0L)
   def fromAddr[T](addr: Addr): Array[T]                      = new Array[T](addr)
   def toAddr[T](arr: Array[T]): Addr                         = arr.$addr
+  def fromArray[T](arr: scala.Array[T]): Array[T]            = macro macros.Array.fromArray[T]
 }

--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -6,8 +6,8 @@ import offheap.internal.macros
 final class Array[A] private (val $addr: Addr) extends AnyVal {
   def isEmpty: Boolean                                   = macro macros.Array.isEmpty
   def nonEmpty: Boolean                                  = macro macros.Array.nonEmpty
-  def size: Size                                         = macro macros.Array.size
-  def length: Size                                       = macro macros.Array.size
+  def size: Array.Size                                   = macro macros.Array.size
+  def length: Array.Size                                 = macro macros.Array.size
   def apply(index: Addr): A                              = macro macros.Array.apply
   def update(index: Addr, value: A): Unit                = macro macros.Array.update
   def foreach(f: A => Unit): Unit                        = macro macros.Array.foreach
@@ -18,6 +18,7 @@ final class Array[A] private (val $addr: Addr) extends AnyVal {
     else super.toString
 }
 object Array {
+  type Size = Int
   def uninit[T](n: Size)(implicit a: Allocator): Array[T]    = macro macros.Array.uninit[T]
   def apply[T](values: T*)(implicit a: Allocator): Array[T]  = macro macros.Array.vararg[T]
   def fill[T](n: Size)(elem: => T)

--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -13,6 +13,7 @@ final class Array[A] private (val $addr: Addr) extends AnyVal {
   def foreach(f: A => Unit): Unit                        = macro macros.Array.foreach
   def map[B](f: A => B)(implicit a: Allocator): Array[B] = macro macros.Array.map[B]
   def toArray: scala.Array[A]                            = macro macros.Array.toArray
+  def clone: Array[A]                                    = macro macros.Array.clone_
 
   override def toString =
     if ($addr == 0L) s"offheap.x64.Array.empty"

--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -13,7 +13,7 @@ final class Array[A] private (val $addr: Addr) extends AnyVal {
   def foreach(f: A => Unit): Unit                        = macro macros.Array.foreach
   def map[B](f: A => B)(implicit a: Allocator): Array[B] = macro macros.Array.map[B]
   def toArray: scala.Array[A]                            = macro macros.Array.toArray
-  def clone: Array[A]                                    = macro macros.Array.clone_
+  def clone(implicit a: Allocator): Array[A]             = macro macros.Array.clone_
 
   override def toString =
     if ($addr == 0L) s"offheap.x64.Array.empty"
@@ -30,5 +30,6 @@ object Array {
   def empty[T]: Array[T]                                     = new Array[T](0L)
   def fromAddr[T](addr: Addr): Array[T]                      = new Array[T](addr)
   def toAddr[T](arr: Array[T]): Addr                         = arr.$addr
-  def fromArray[T](arr: scala.Array[T]): Array[T]            = macro macros.Array.fromArray[T]
+  def fromArray[T](arr: scala.Array[T])(implicit a: Allocator): Array[T] =
+    macro macros.Array.fromArray[T]
 }

--- a/jmh/src/main/scala/Allocation.scala
+++ b/jmh/src/main/scala/Allocation.scala
@@ -4,9 +4,9 @@ import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
 import offheap._
 
-class Point(val x: Float, val y: Float)
+class Point(val x: Int, val y: Int)
 
-@data class OffheapPoint(val x: Float, val y: Float)
+@data class OffheapPoint(val x: Int, val y: Int)
 
 @State(Scope.Thread)
 class OffheapAllocation {

--- a/jmh/src/main/scala/Array.scala
+++ b/jmh/src/main/scala/Array.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import offheap._, internal.Memory.UNSAFE
 
 @State(Scope.Thread)
-class ArrayBench {
+class Array {
   implicit val alloc = Allocator()
   implicit val pool  = Pool(alloc, pageSize = 81920, chunkSize = 81920)
   val jarr: scala.Array[Long] = (0 to 9999).toArray.map(_.toLong)
@@ -86,7 +86,7 @@ class ArrayBench {
   def onheapForeach(bh: Blackhole) = jarr.foreach { v => bh.consume(v) }
 
   @Benchmark
-  def offheapMap = Region { r => arr.map(_ * 2) }
+  def offheapMap = Region { r => arr.map(_ * 2)(r) }
 
   @Benchmark
   def onheapMap = jarr.map(_ * 2)

--- a/jmh/src/main/scala/LoopBench.scala
+++ b/jmh/src/main/scala/LoopBench.scala
@@ -1,0 +1,42 @@
+package offheap.test.jmh
+
+import org.openjdk.jmh.annotations._
+import offheap._, internal.Memory.UNSAFE
+
+@State(Scope.Thread)
+class LoopBench {
+  var length = 10000
+  val uarr: Long = {
+    val addr = UNSAFE.allocateMemory(length * 4)
+    var i = 0
+    while (i <= length) {
+      UNSAFE.putInt(addr + i * 4, i)
+      i += 1
+    }
+    addr
+  }
+
+  @Benchmark
+  def unsafeSum1 = {
+    var sum = 0
+    val bound = length
+    var i = 0
+    while (i != bound) {
+      sum += UNSAFE.getInt(uarr + 4 * i)
+      i += 1
+    }
+    sum
+  }
+
+  @Benchmark
+  def unsafeSum2 = {
+    var sum = 0
+    val bound = uarr + 4 * length
+    var p = uarr
+    while (p != bound) {
+      sum += UNSAFE.getInt(p)
+      p += 4
+    }
+    sum
+  }
+}

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -15,86 +15,78 @@ class Array(val c: blackbox.Context) extends Common {
   def nonEmpty = q"${c.prefix.tree}.$addr != 0L"
 
   def size = stabilized(c.prefix.tree) { pre =>
-    read(q"$pre.$addr", SizeTpe)
+    read(q"$pre.$addr", ArraySizeTpe)
   }
+
+  def sizeOfArraySize = q"$offheap.sizeOf[$ArraySizeTpe]"
 
   def boundsChecked(index: Tree)(ifOk: Tree => Tree => Tree) =
     stabilized(c.prefix.tree) { pre =>
       stabilized(index) { idx =>
-        val size = fresh("size")
-        val happy = ifOk(pre)(idx)
         q"""
-          if ($CheckedModule.BOUNDS) {
-            val $size: $SizeTpe = ${read(q"$pre.$addr", AddrTpe)}
-            if ($idx >= 0 && $idx < $size) $happy
-            else throw new _root_.java.lang.IndexOutOfBoundsException($index.toString)
-          } else $happy
+          if ($CheckedModule.BOUNDS)
+            if ($idx < 0 || $idx >= ${read(q"$pre.$addr", ArraySizeTpe)})
+              throw new _root_.java.lang.IndexOutOfBoundsException($idx.toString)
+          ${ifOk(pre)(idx)}
         """
       }
     }
 
   def apply(index: Tree) =
     boundsChecked(index) { pre => i =>
-      val naddr = fresh("addr")
-      q"""
-        val $naddr = $pre.$addr + $offheap.sizeOf[$SizeTpe] + $i * $offheap.sizeOf[$A]
-        ${read(q"$naddr", A)}
-      """
+      read(q"$pre.$addr + $sizeOfArraySize + $i * $offheap.sizeOf[$A]", A)
     }
 
   def update(index: Tree, value: Tree) =
     boundsChecked(index) { pre => i =>
-      val naddr = fresh("addr")
-      q"""
-        val $naddr = $pre.$addr + $offheap.sizeOf[$SizeTpe] + $i * $offheap.sizeOf[$A]
-        ${write(q"$naddr", A, value)}
-      """
+      write(q"$pre.$addr + $sizeOfArraySize + $i * $offheap.sizeOf[$A]", A, value)
     }
 
-  def foreach(f: Tree) =
+  def foreach(f: Tree) = debug("foreach") {
     stabilized(c.prefix.tree) { pre =>
       q"""
         if ($pre.nonEmpty)
-          ${iterate(A, pre, p => app(f, read(p, A)))}
+          ${iterate(A, pre, _ => p => app(f, read(p, A)))}
       """
     }
+  }
 
-  def iterate(T: Type, pre: Tree, f: Tree => Tree) = {
-    val p = fresh("p")
-    val len = fresh("len")
-    val step = fresh("step")
-    val bound = fresh("bound")
+  def iterate(T: Type, pre: Tree, f: Tree => Tree => Tree) = {
+    val i = freshVar("i", IntTpe, q"0")
+    val len = freshVal("len", ArraySizeTpe, read(q"$pre.$addr", ArraySizeTpe))
+    val base = freshVal("base", AddrTpe, q"$pre.$addr + $sizeOfArraySize")
     q"""
-      var $p: $AddrTpe = $pre.$addr
-      val $len: $SizeTpe = ${read(q"$p", SizeTpe)}
-      $p += $offheap.sizeOf[$SizeTpe]
-      val $step: $SizeTpe = $offheap.sizeOf[$T]
-      val $bound: $AddrTpe = $p + $len * $step
-      while ($p < $bound) {
-        ${f(q"$p")}
-        $p += $step
+      $len
+      $base
+      $i
+      while (${i.symbol} < ${len.symbol}) {
+        ..${f(q"${i.symbol}")(q"${base.symbol} + ${i.symbol} * ${sizeOf(T)}")}
+        ${i.symbol} += 1
       }
     """
   }
 
-  def map[B: WeakTypeTag](f: Tree)(a: Tree) = {
+  def map[B: WeakTypeTag](f: Tree)(a: Tree) = debug("map") {
     val B = wt[B]
     assertAllocatable(B)
     stabilized(c.prefix.tree) { pre =>
       stabilized(a) { alloc =>
-        val narr = fresh("narr")
-        val v    = fresh("v")
-        val p    = fresh("p")
-        val step = fresh("step")
+        val narr   = freshVal("narr", appliedType(ArrayTpe, B),
+                       q"$ArrayModule.uninit[$B]($pre.length)($alloc)")
+        val base   = freshVal("base", AddrTpe,
+                       q"${narr.symbol}.$addr + $sizeOfArraySize")
+        val body =
+          iterate(A, pre, i => p => q"""
+            ..${write(q"${base.symbol} + ${i.symbol} * ${sizeOf(B)}", B, app(f, read(p, A)))}
+          """)
         q"""
-          val $narr = $ArrayModule.uninit[$B]($pre.length)($alloc)
-          val $step = $offheap.sizeOf[$B]
-          var $p    = $narr.$addr + $offheap.sizeOf[$SizeTpe]
-          $pre.foreach { $v: $A =>
-            ${write(q"$p", B, app(f, q"$v"))}
-            $p += $step
+          if ($pre.isEmpty) $ArrayModule.empty[$B]
+          else {
+            $narr
+            $base
+            ..$body
+            ${narr.symbol}
           }
-          $narr
         """
       }
     }
@@ -105,15 +97,15 @@ class Array(val c: blackbox.Context) extends Common {
     assertAllocatable(T)
     stabilized(n) { len =>
       stabilized(a) { alloc =>
-        val naddr = fresh("addr")
-        val size = q"$offheap.sizeOf[$AddrTpe] + $len * $offheap.sizeOf[$T]"
+        val size = q"$sizeOfArraySize + $len * $offheap.sizeOf[$T]"
+        val naddr = freshVal("addr", AddrTpe, q"$alloc.allocate($size)")
         q"""
           if ($len < 0) throw new $IllegalArgumentExceptionClass
           else if ($len == 0) $ArrayModule.empty[$T]
           else {
-            val $naddr = $alloc.allocate($size)
-            ${write(q"$naddr", SizeTpe, len)}
-            $ArrayModule.fromAddr[$T]($naddr)
+            ${naddr}
+            ${write(q"${naddr.symbol}", ArraySizeTpe, len)}
+            $ArrayModule.fromAddr[$T](${naddr.symbol})
           }
         """
       }
@@ -133,9 +125,9 @@ class Array(val c: blackbox.Context) extends Common {
         write(q"$naddr + $i * $step", T, v)
       }
       q"""
-        val $arr = $ArrayModule.uninit[$T](${values.length})($alloc)
-        val $step = $offheap.sizeOf[$T]
-        val $naddr = $arr.$addr + $offheap.sizeOf[$AddrTpe]
+        val $arr   = $ArrayModule.uninit[$T](${values.length})($alloc)
+        val $step  = $offheap.sizeOf[$T]
+        val $naddr = $arr.$addr + $sizeOfArraySize
         ..$writes
         $arr
       """
@@ -149,7 +141,7 @@ class Array(val c: blackbox.Context) extends Common {
         val arr = fresh("arr")
         q"""
           val $arr = $ArrayModule.uninit[$T]($len)($alloc)
-          ${iterate(T, q"$arr", p => write(p, T, elem))}
+          ${iterate(T, q"$arr", _ => p => write(p, T, elem))}
           $arr
         """
       }

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -288,6 +288,8 @@ trait Common extends Definitions {
     appSubs(f, argValue, identity)
 
   def stabilized(tree: Tree)(f: Tree => Tree) = tree match {
+    case q"${const: Literal}" =>
+      f(const)
     case q"${refTree: RefTree}" if isSemiStable(refTree.symbol) =>
       f(refTree)
     case _ =>

--- a/macros/src/main/scala/offheap/internal/macros/Definitions.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Definitions.scala
@@ -12,8 +12,9 @@ trait Definitions {
   import c.universe.rootMirror._
 
   val StringBuilderClass            = staticClass("scala.collection.mutable.StringBuilder")
-  val NullPointerExceptionClass     = staticClass("java.lang.NullPointerException")
-  val IllegalArgumentExceptionClass = staticClass("java.lang.IllegalArgumentException")
+  val NullPointerExceptionClass      = staticClass("java.lang.NullPointerException")
+  val IllegalArgumentExceptionClass  = staticClass("java.lang.IllegalArgumentException")
+  val IndexOutOfBoundsExceptionClass = staticClass("java.lang.IndexOutOfBoundsException")
 
   val RegionClass             = staticClass("offheap.Region")
   val AllocatorClass          = staticClass("offheap.Allocator")

--- a/macros/src/main/scala/offheap/internal/macros/Definitions.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Definitions.scala
@@ -11,9 +11,6 @@ trait Definitions {
   import c.universe.definitions._
   import c.universe.rootMirror._
 
-  val AddrTpe = LongClass.toType
-  val SizeTpe = LongClass.toType
-
   val StringBuilderClass            = staticClass("scala.collection.mutable.StringBuilder")
   val NullPointerExceptionClass     = staticClass("java.lang.NullPointerException")
   val IllegalArgumentExceptionClass = staticClass("java.lang.IllegalArgumentException")
@@ -47,6 +44,11 @@ trait Definitions {
 
   val offheap  = staticPackage("offheap")
   val internal = staticPackage("offheap.internal")
+
+  val AddrTpe      = LongTpe
+  val SizeTpe      = LongTpe
+  val ArrayTpe     = ArrayClass.toType
+  val ArraySizeTpe = IntTpe
 
   val initializer  = TermName("$init")
   val layout       = TermName("$layout")

--- a/macros/src/main/scala/offheap/internal/macros/Region.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Region.scala
@@ -9,14 +9,14 @@ class Region(val c: whitebox.Context) extends Common {
   import c.universe.definitions._
 
   def apply(f: Tree)(pool: Tree) = {
-    val r = fresh("r")
-    val res = fresh("res")
-    val body = app(f, q"$r")
+    val r    = freshVal("r", RegionClass.toType, q"$RegionModule.open($pool)")
+    val res  = fresh("res")
+    val body = app(f, q"${r.symbol}")
     q"""
-      val $r = $RegionModule.open($pool)
+      $r
       val $res =
         try $body
-        finally $r.close()
+        finally ${r.symbol}.close()
       $res
     """
   }

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -83,4 +83,20 @@ class ArraySuite extends FunSuite {
     assert(Array(1).nonEmpty)
     assert(!Array(1).isEmpty)
   }
+
+  test("offheap to onheap") {
+    val arr = Array(1, 2, 3, 4, 5)
+    val jarr = arr.toArray
+    val jarr2 = scala.Array(1, 2, 3, 4, 5)
+    for (i <- 0 to 4)
+      assert(jarr(i) == jarr2(i))
+  }
+
+  test("onheap to offheap") {
+    val jarr = scala.Array(1, 2, 3, 4, 5)
+    val arr = Array.fromArray(jarr)
+    val arr2 = Array(1, 2, 3, 4, 5)
+    for (i <- 0 to 4)
+      assert(arr(i) == arr2(i))
+  }
 }

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -48,13 +48,21 @@ class ArraySuite extends FunSuite {
     intercept[IndexOutOfBoundsException] { arr(4)  }
   }
 
-  ignore("copy") {
+  test("copy") {
     val arr1 = Array(0, 0, 0, 0, 0, 0, 0, 0)
     val arr2 = Array(1, 1, 1, 1, 1, 1, 1, 1)
     Array.copy(arr2, 1, arr1, 2, 3)
     val arr3 = Array(0, 0, 1, 1, 1, 0, 0, 0)
     for (i <- 0 to 7)
       assert(arr1(i) == arr3(i))
+  }
+
+  test("copy out of bounds") {
+    val arr1 = Array(0, 0, 0)
+    val arr2 = Array(1, 1, 1, 1, 1, 1, 1, 1)
+    intercept[IndexOutOfBoundsException] {
+      Array.copy(arr2, 1, arr1, 2, 3)
+    }
   }
 
   test("arrays can be fields in data classes") {

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -14,6 +14,10 @@ class ArraySuite extends FunSuite {
     assert(arr.size == 10)
   }
 
+  test("uninit empty") {
+    assert(Array.uninit[Int](0).isEmpty)
+  }
+
   test("vararg") {
     var arr = Array(1, 2, 3, 4)
     assert(arr.nonEmpty)
@@ -31,6 +35,10 @@ class ArraySuite extends FunSuite {
     arr.foreach { v => assert(v == 42) }
   }
 
+  test("fill empty") {
+    assert(Array.fill(0)(0).isEmpty)
+  }
+
   test("map") {
     val arr = Array(1, 2, 3, 4)
     val narr = arr.map(v => (v + 1).toLong)
@@ -40,6 +48,10 @@ class ArraySuite extends FunSuite {
     assert(narr(1) == 3L)
     assert(narr(2) == 4L)
     assert(narr(3) == 5L)
+  }
+
+  test("map empty") {
+    assert(Array.empty[Int].map(_ * 2).isEmpty)
   }
 
   test("out of bounds") {
@@ -65,6 +77,13 @@ class ArraySuite extends FunSuite {
     }
   }
 
+  test("copy empty") {
+    val arr1 = Array(0, 0, 0, 0)
+    val arr2 = Array.empty[Int]
+    intercept[IllegalArgumentException] { Array.copy(arr2, 0, arr1, 0, 4) }
+    intercept[IllegalArgumentException] { Array.copy(arr1, 0, arr2, 0, 4) }
+  }
+
   test("arrays can be fields in data classes") {
     val arr1 = Array(1, 2, 3)
     val arr2 = Array(2, 3, 4)
@@ -87,16 +106,38 @@ class ArraySuite extends FunSuite {
   test("offheap to onheap") {
     val arr = Array(1, 2, 3, 4, 5)
     val jarr = arr.toArray
+    assert(jarr.length == 5)
     val jarr2 = scala.Array(1, 2, 3, 4, 5)
     for (i <- 0 to 4)
       assert(jarr(i) == jarr2(i))
   }
 
+  test("empty offheap to onheap") {
+    assert(Array.empty[Int].toArray.isEmpty)
+  }
+
   test("onheap to offheap") {
     val jarr = scala.Array(1, 2, 3, 4, 5)
     val arr = Array.fromArray(jarr)
+    assert(arr.length == 5)
     val arr2 = Array(1, 2, 3, 4, 5)
     for (i <- 0 to 4)
       assert(arr(i) == arr2(i))
+  }
+
+  test("empty onheap to offheap") {
+    assert(Array.fromArray(scala.Array.empty[Int]).isEmpty)
+  }
+
+  test("clone") {
+    val arr = Array(1, 2, 3, 4, 5)
+    val arr2 = arr.clone
+    assert(arr2.size == 5)
+    for (i <- 0 to 4)
+      assert(arr(i) == arr(i))
+  }
+
+  test("clone empty") {
+    assert(Array.empty[Int].clone.isEmpty)
   }
 }


### PR DESCRIPTION
1. Makes arrays `Int`-sized. This significantly improves iteration performance.
1. New implementation of `copy` with bounds checks
1. Adds `fromArray` and `toArray` to convert from and to `scala.Array`.
1. Adds `clone` method
1. More tests 