### PR TITLE
Introduces embedded arrays

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -4,16 +4,16 @@ import scala.language.experimental.{macros => CanMacro}
 import offheap.internal.macros
 
 final class Array[A] private (val $addr: Addr) extends AnyVal {
-  def isEmpty: Boolean                                   = macro macros.Array.isEmpty
-  def nonEmpty: Boolean                                  = macro macros.Array.nonEmpty
-  def size: Array.Size                                   = macro macros.Array.size
-  def length: Array.Size                                 = macro macros.Array.size
-  def apply(index: Addr): A                              = macro macros.Array.apply
-  def update(index: Addr, value: A): Unit                = macro macros.Array.update
-  def foreach(f: A => Unit): Unit                        = macro macros.Array.foreach
-  def map[B](f: A => B)(implicit a: Allocator): Array[B] = macro macros.Array.map[B]
-  def toArray: scala.Array[A]                            = macro macros.Array.toArray
-  def clone(implicit a: Allocator): Array[A]             = macro macros.Array.clone_
+  def isEmpty: Boolean                                   = macro macros.ArrayApi.isEmpty
+  def nonEmpty: Boolean                                  = macro macros.ArrayApi.nonEmpty
+  def size: Array.Size                                   = macro macros.ArrayApi.size
+  def length: Array.Size                                 = macro macros.ArrayApi.size
+  def apply(index: Addr): A                              = macro macros.ArrayApi.apply
+  def update(index: Addr, value: A): Unit                = macro macros.ArrayApi.update
+  def foreach(f: A => Unit): Unit                        = macro macros.ArrayApi.foreach
+  def map[B](f: A => B)(implicit a: Allocator): Array[B] = macro macros.ArrayApi.map[B]
+  def toArray: scala.Array[A]                            = macro macros.ArrayApi.toArray
+  def clone(implicit a: Allocator): Array[A]             = macro macros.ArrayApi.clone_
 
   override def toString =
     if ($addr == 0L) s"offheap.x64.Array.empty"
@@ -21,15 +21,16 @@ final class Array[A] private (val $addr: Addr) extends AnyVal {
 }
 object Array {
   type Size = Int
-  def uninit[T](n: Size)(implicit a: Allocator): Array[T]    = macro macros.Array.uninit[T]
-  def apply[T](values: T*)(implicit a: Allocator): Array[T]  = macro macros.Array.vararg[T]
+  def uninit[T](n: Size)(implicit a: Allocator): Array[T]    = macro macros.ArrayModule.uninit[T]
+  def apply[T](values: T*)(implicit a: Allocator): Array[T]  = macro macros.ArrayModule.vararg[T]
   def fill[T](n: Size)(elem: => T)
-             (implicit a: Allocator): Array[T]               = macro macros.Array.fill[T]
+             (implicit a: Allocator): Array[T]               = macro macros.ArrayModule.fill[T]
   def copy[T](from: Array[T], fromIndex: Addr,
-              to: Array[T], toIndex: Addr, size: Size): Unit = macro macros.Array.copy[T]
+              to: Array[T], toIndex: Addr, size: Size): Unit = macro macros.ArrayModule.copy[T]
+  def fromArray[T](arr: scala.Array[T])
+                  (implicit a: Allocator): Array[T]          = macro macros.ArrayModule.fromArray[T]
+
   def empty[T]: Array[T]                                     = new Array[T](0L)
   def fromAddr[T](addr: Addr): Array[T]                      = new Array[T](addr)
   def toAddr[T](arr: Array[T]): Addr                         = arr.$addr
-  def fromArray[T](arr: scala.Array[T])(implicit a: Allocator): Array[T] =
-    macro macros.Array.fromArray[T]
 }

--- a/core/src/main/scala/offheap/EmbedArray.scala
+++ b/core/src/main/scala/offheap/EmbedArray.scala
@@ -1,0 +1,36 @@
+package offheap
+
+import scala.language.experimental.{macros => CanMacro}
+import offheap.internal.macros
+
+final class EmbedArray[A] private (val $addr: Addr) extends AnyVal {
+  def isEmpty: Boolean                                        = macro macros.EmbedArrayApi.isEmpty
+  def nonEmpty: Boolean                                       = macro macros.EmbedArrayApi.nonEmpty
+  def size: EmbedArray.Size                                   = macro macros.EmbedArrayApi.size
+  def length: EmbedArray.Size                                 = macro macros.EmbedArrayApi.size
+  def apply(index: Addr): A                                   = macro macros.EmbedArrayApi.apply
+  def update(index: Addr, value: A): Unit                     = macro macros.EmbedArrayApi.update
+  def foreach(f: A => Unit): Unit                             = macro macros.EmbedArrayApi.foreach
+  def map[B](f: A => B)(implicit a: Allocator): EmbedArray[B] = macro macros.EmbedArrayApi.map[B]
+  def todArray: scala.Array[A]                                = macro macros.EmbedArrayApi.toArray
+  def clone(implicit a: Allocator): EmbedArray[A]             = macro macros.EmbedArrayApi.clone_
+
+  override def toString =
+    if ($addr == 0L) s"offheap.x64.EmbedArray.empty"
+    else super.toString
+}
+object EmbedArray {
+  type Size = Int
+  def uninit[T](n: Size)(implicit a: Allocator): EmbedArray[T]    = macro macros.EmbedArrayModule.uninit[T]
+  def apply[T](values: T*)(implicit a: Allocator): EmbedArray[T]  = macro macros.EmbedArrayModule.vararg[T]
+  def fill[T](n: Size)(elem: => T)
+             (implicit a: Allocator): EmbedArray[T]               = macro macros.EmbedArrayModule.fill[T]
+  def copy[T](from: EmbedArray[T], fromIndex: Addr,
+              to: EmbedArray[T], toIndex: Addr, size: Size): Unit = macro macros.EmbedArrayModule.copy[T]
+  def fromArray[T](arr: scala.Array[T])
+                  (implicit a: Allocator): EmbedArray[T]          = macro macros.EmbedArrayModule.fromArray[T]
+
+  def empty[T]: EmbedArray[T]                                     = new EmbedArray[T](0L)
+  def fromAddr[T](addr: Addr): EmbedArray[T]                      = new EmbedArray[T](addr)
+  def toAddr[T](arr: EmbedArray[T]): Addr                         = arr.$addr
+}

--- a/core/src/main/scala/offheap/package.scala
+++ b/core/src/main/scala/offheap/package.scala
@@ -10,5 +10,5 @@ package object offheap {
   def sizeOf[T]: Size                  = macro macros.Util.sizeOf_[T]
   def sizeOfEmbed[T]: Size             = macro macros.Util.sizeOfEmbed_[T]
   def offsetOf[T](field: String): Size = macro macros.Util.offsetOf[T]
-  def strideOf[T]: Size                = macro macros.Util.strideOf[T]
+  def strideOf[T]: Size                = macro macros.Util.strideOf_[T]
 }

--- a/core/src/main/scala/offheap/package.scala
+++ b/core/src/main/scala/offheap/package.scala
@@ -6,8 +6,8 @@ package object offheap {
   type Size = Long
 
   def alignmentOf[T]: Size             = macro macros.Util.alignmentOf_[T]
-  def alignmentOfData[T]: Size         = macro macros.Util.alignmentOfData_[T]
+  def alignmentOfEmbed[T]: Size        = macro macros.Util.alignmentOfEmbed_[T]
   def sizeOf[T]: Size                  = macro macros.Util.sizeOf_[T]
-  def sizeOfData[T]: Size              = macro macros.Util.sizeOfData_[T]
+  def sizeOfEmbed[T]: Size             = macro macros.Util.sizeOfEmbed_[T]
   def offsetOf[T](field: String): Size = macro macros.Util.offsetOf[T]
 }

--- a/core/src/main/scala/offheap/package.scala
+++ b/core/src/main/scala/offheap/package.scala
@@ -10,4 +10,5 @@ package object offheap {
   def sizeOf[T]: Size                  = macro macros.Util.sizeOf_[T]
   def sizeOfEmbed[T]: Size             = macro macros.Util.sizeOfEmbed_[T]
   def offsetOf[T](field: String): Size = macro macros.Util.offsetOf[T]
+  def strideOf[T]: Size                = macro macros.Util.strideOf[T]
 }

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -11,6 +11,7 @@ trait ArrayCommon extends Common {
 
   def isEmbed: Boolean
   def MyArrayClass  = if (isEmbed) EmbedArrayClass else ArrayClass
+  def MyArrayTpe    = MyArrayClass.asType.toType
   def MyArrayModule = if (isEmbed) EmbedArrayModule else ArrayModule
 
   def throwIllegalArgument(v: Tree) =
@@ -103,7 +104,7 @@ trait ArrayApiCommon extends ArrayCommon {
     assertAllocatable(B)
     stabilized(c.prefix.tree) { pre =>
       stabilized(a) { alloc =>
-        val narr = freshVal("narr", appliedType(ArrayTpe, B),
+        val narr = freshVal("narr", appliedType(MyArrayTpe, B),
                             q"$MyArrayModule.uninit[$B]($pre.length)($alloc)")
         val base = freshVal("base", AddrTpe,
                             q"${narr.symbol}.$addr + $sizeOfHeader")

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -20,9 +20,7 @@ trait ArrayCommon extends Common {
   def throwOutOfBounds(idx: Tree) =
     q"throw new $IndexOutOfBoundsExceptionClass($idx.toString)"
 
-  def strideOf(T: Type) =
-    if (!isEmbed) sizeOf(T)
-    else padded(sizeOfEmbed(T), alignmentOfEmbed(T))
+  def strideOf(T: Type): Long = strideOf(T, isEmbed)
 
   def sizeOfHeader =
     q"$offheap.sizeOf[$LongTpe]"

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -76,10 +76,10 @@ class Array(val c: blackbox.Context) extends Common {
     assertAllocatable(B)
     stabilized(c.prefix.tree) { pre =>
       stabilized(a) { alloc =>
-        val narr   = freshVal("narr", appliedType(ArrayTpe, B),
-                       q"$ArrayModule.uninit[$B]($pre.length)($alloc)")
-        val base   = freshVal("base", AddrTpe,
-                       q"${narr.symbol}.$addr + $sizeOfArraySize")
+        val narr = freshVal("narr", appliedType(ArrayTpe, B),
+                            q"$ArrayModule.uninit[$B]($pre.length)($alloc)")
+        val base = freshVal("base", AddrTpe,
+                            q"${narr.symbol}.$addr + $sizeOfArraySize")
         val body =
           iterate(A, pre, i => p => q"""
             ..${write(q"${base.symbol} + ${i.symbol} * ${sizeOf(B)}", B, app(f, read(p, A)))}

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -269,9 +269,12 @@ trait Common extends Definitions {
         ..${initialize(clazz, naddr, args, discardResult = true, prezeroed = false)}
       """
     case _ =>
-      val from = q"${tpe.typeSymbol.companion}.toAddr($value)"
+      val from = fresh("from")
       val size = sizeOfEmbed(tpe)
-      nullChecked(from, q"$MemoryModule.copy($from, $addr, $size)")
+      q"""
+        val $from = ${tpe.typeSymbol.companion}.toAddr($value)
+        ${nullChecked(q"$from", q"$MemoryModule.copy($from, $addr, $size)")}
+      """
   }
 
   def isSemiStable(sym: Symbol) =

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -433,4 +433,8 @@ trait Common extends Definitions {
   def assign(addr: Tree, f: Field, value: Tree) =
     if (f.isEmbed) writeEmbed(q"$addr + ${f.offset}", f.tpe, value)
     else write(q"$addr + ${f.offset}", f.tpe, value)
+
+  def strideOf(T: Type, isEmbed: Boolean): Long =
+    if (!isEmbed) sizeOf(T)
+    else padded(sizeOfEmbed(T), alignmentOfEmbed(T))
 }

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -73,11 +73,11 @@ trait Common extends Definitions {
 
   case class Field(name: String, after: Tree, tpe: Type,
                    annots: List[Tree], offset: Long) {
-    lazy val isData    = annots.collect { case q"new $c" if c.symbol == EmbedClass => c }.nonEmpty
+    lazy val isEmbed   = annots.collect { case q"new $c" if c.symbol == EmbedClass => c }.nonEmpty
     lazy val inCtor    = annots.collect { case q"new $c" if c.symbol == CtorClass => c }.nonEmpty
          val inBody    = !inCtor
-    lazy val size      = if (isData) sizeOfData(tpe) else sizeOf(tpe)
-    lazy val alignment = if (isData) alignmentOfData(tpe) else alignmentOf(tpe)
+    lazy val size      = if (isEmbed) sizeOfEmbed(tpe) else sizeOf(tpe)
+    lazy val alignment = if (isEmbed) alignmentOfEmbed(tpe) else alignmentOf(tpe)
   }
   object Field {
     implicit val lift: Liftable[Field] = Liftable { f =>
@@ -206,7 +206,7 @@ trait Common extends Definitions {
     case _                     => abort(s"can't compute size of $tpe")
   }
 
-  def sizeOfData(tpe: Type): Long = tpe match {
+  def sizeOfEmbed(tpe: Type): Long = tpe match {
     case Clazz(clazz) => clazz.size
     case _            => abort(s"$tpe is not a an offheap class")
   }
@@ -221,7 +221,7 @@ trait Common extends Definitions {
     case _                     => abort(s"can't comput alignment for $tpe")
   }
 
-  def alignmentOfData(tpe: Type) = tpe match {
+  def alignmentOfEmbed(tpe: Type) = tpe match {
     case Clazz(clazz) => clazz.alignment
     case _            => abort(s"$tpe is not an offheap class")
   }

--- a/macros/src/main/scala/offheap/internal/macros/Definitions.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Definitions.scala
@@ -11,7 +11,7 @@ trait Definitions {
   import c.universe.definitions._
   import c.universe.rootMirror._
 
-  val StringBuilderClass            = staticClass("scala.collection.mutable.StringBuilder")
+  val StringBuilderClass             = staticClass("scala.collection.mutable.StringBuilder")
   val NullPointerExceptionClass      = staticClass("java.lang.NullPointerException")
   val IllegalArgumentExceptionClass  = staticClass("java.lang.IllegalArgumentException")
   val IndexOutOfBoundsExceptionClass = staticClass("java.lang.IndexOutOfBoundsException")
@@ -19,6 +19,7 @@ trait Definitions {
   val RegionClass             = staticClass("offheap.Region")
   val AllocatorClass          = staticClass("offheap.Allocator")
   val ArrayClass              = staticClass("offheap.Array")
+  val EmbedArrayClass         = staticClass("offheap.EmbedArray")
   val EmbedClass              = staticClass("offheap.embed")
   val DataClass               = staticClass("offheap.internal.Data")
   val EnumClass               = staticClass("offheap.internal.Enum")
@@ -34,14 +35,15 @@ trait Definitions {
   val CompleteClass           = staticClass("offheap.internal.Complete")
   val CtorClass               = staticClass("offheap.internal.Ctor")
 
-  val RegionModule    = staticModule("offheap.Region")
-  val PoolModule      = staticModule("offheap.Pool")
-  val ArrayModule     = staticModule("offheap.Array")
-  val SanitizerModule = staticModule("offheap.internal.Sanitizer")
-  val MethodModule    = staticModule("offheap.internal.Method")
-  val LayoutModule    = staticModule("offheap.internal.Layout")
-  val MemoryModule    = staticModule("offheap.internal.Memory")
-  val CheckedModule   = staticModule("offheap.internal.Checked")
+  val RegionModule     = staticModule("offheap.Region")
+  val PoolModule       = staticModule("offheap.Pool")
+  val ArrayModule      = staticModule("offheap.Array")
+  val EmbedArrayModule = staticModule("offheap.EmbedArray")
+  val SanitizerModule  = staticModule("offheap.internal.Sanitizer")
+  val MethodModule     = staticModule("offheap.internal.Method")
+  val LayoutModule     = staticModule("offheap.internal.Layout")
+  val MemoryModule     = staticModule("offheap.internal.Memory")
+  val CheckedModule    = staticModule("offheap.internal.Checked")
 
   val offheap  = staticPackage("offheap")
   val internal = staticPackage("offheap.internal")

--- a/macros/src/main/scala/offheap/internal/macros/Layout.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Layout.scala
@@ -30,10 +30,7 @@ class Layout(val c: blackbox.Context) extends Common {
         val q"${prev: Field}" = ExtractField.unapply(c.typecheck(after).symbol).get.head
         prev.offset + prev.size
     }
-    val padding =
-      if (baseoffset % alignment == 0) 0
-      else alignment - baseoffset % alignment
-    q"${baseoffset + padding}"
+    q"${padded(baseoffset, alignment)}"
   }
 
   def markComplete[C: WeakTypeTag] = {

--- a/macros/src/main/scala/offheap/internal/macros/Layout.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Layout.scala
@@ -17,12 +17,12 @@ class Layout(val c: blackbox.Context) extends Common {
 
   def field[C: WeakTypeTag](after: Tree, tag: Tree, annots: Tree) = inLayout(wt[C]) {
     val q"${tpe: Type}" = tag
-    val isData = annots.collect { case q"new $c" if c.symbol == EmbedClass => c }.nonEmpty
+    val isEmbed = annots.collect { case q"new $c" if c.symbol == EmbedClass => c }.nonEmpty
     val alignment =
-      if (isData) {
+      if (isEmbed) {
         assertEmbeddable(tpe)
         assertNotInLayout(tpe.typeSymbol, "illegal recursive embedding")
-        alignmentOfData(tpe)
+        alignmentOfEmbed(tpe)
       } else alignmentOf(tpe)
     val baseoffset = after match {
       case q"" => 0

--- a/macros/src/main/scala/offheap/internal/macros/Method.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Method.scala
@@ -9,20 +9,6 @@ class Method(val c: blackbox.Context) extends Common {
   import c.universe.definitions._
   import c.internal._, decorators._
 
-  def nullChecked(addr: Tree, ifOk: Tree) =
-    q"""
-      if ($CheckedModule.NULL)
-        if ($addr == 0L) throw new $NullPointerExceptionClass
-      $ifOk
-    """
-
-  def access(addr: Tree, f: Field) =
-    if (f.isEmbed) {
-      val companion = f.tpe.typeSymbol.companion
-      q"$companion.fromAddr($addr + ${f.offset})"
-    } else
-      read(q"$addr + ${f.offset}", f.tpe)
-
   def accessor[C: WeakTypeTag, T: WeakTypeTag](addr: Tree, name: Tree): Tree = {
     val C = wt[C]
     assertAllocatable(C)
@@ -36,15 +22,6 @@ class Method(val c: blackbox.Context) extends Common {
     }
   }
 
-  def assign(addr: Tree, f: Field, value: Tree) =
-    if (f.isEmbed) {
-      val companion = f.tpe.typeSymbol.companion
-      val from      = q"$companion.toAddr($value)"
-      val to        = q"$addr + ${f.offset}"
-      val size      = sizeOfEmbed(f.tpe)
-      nullChecked(from, q"$MemoryModule.copy($from, $to, $size)")
-    } else write(q"$addr + ${f.offset}", f.tpe, value)
-
   def assigner[C: WeakTypeTag, T: WeakTypeTag](addr: Tree, name: Tree, value: Tree) = {
     val C = wt[C]
     assertAllocatable(C)
@@ -56,57 +33,6 @@ class Method(val c: blackbox.Context) extends Common {
     }.getOrElse {
       abort(s"$C doesn't have field `$nameStr`")
     }
-  }
-
-  object Allocation {
-    final case class Attachment(clazz: Clazz, args: List[Tree], alloc: Tree)
-    def apply(clazz: Clazz, args: List[Tree], alloc: Tree, result: Tree): Tree =
-      result.updateAttachment(Attachment(clazz, args, alloc))
-    def unapply(tree: Tree): Option[(Clazz, List[Tree], Tree)] = tree match {
-      case q"$inner: $_" =>
-        inner.attachments.get[Attachment].map { a => (a.clazz, a.args, a.alloc) }
-      case _ =>
-        None
-    }
-  }
-
-  def flatten(trees: List[Tree]) =
-    trees.reduceOption { (l, r) => q"..$l; ..$r" }.getOrElse(q"")
-
-  def initialize(clazz: Clazz, addr: TermName, args: Seq[Tree],
-                 discardResult: Boolean, prezeroed: Boolean): Tree = {
-    val (preamble, zeroed) =
-      if (clazz.fields.filter(_.inBody).isEmpty || prezeroed) (q"", prezeroed)
-      else (q"$MemoryModule.zero($addr, ${clazz.size})", true)
-    val values = clazz.tag.map(_.value) ++: args
-    val writes = clazz.fields.zip(values).map { case (f, v) =>
-      v match {
-        case Allocation(fclazz, fargs, _) if f.isEmbed =>
-          def init(faddr: TermName) =
-            initialize(fclazz, faddr, fargs, discardResult = true, prezeroed = zeroed)
-          if (f.offset == 0)
-            init(addr)
-          else {
-            val faddr = fresh("addr")
-            q"""
-              val $faddr = $addr + ${f.offset}
-              ..${init(faddr)}
-            """
-          }
-        case _ =>
-          assign(q"$addr", f, v)
-      }
-    }
-    val newC = q"${clazz.companion}.fromAddr($addr)"
-    val instantiated =
-      if (clazz.hasInit) q"$newC.$initializer"
-      else if (discardResult) q""
-      else newC
-    q"""
-      ..$preamble
-      ..${flatten(writes)}
-      ..$instantiated
-    """
   }
 
   def allocate(anyC: Any, anyArgs: Any, anyAlloc: Any): Tree = {

--- a/macros/src/main/scala/offheap/internal/macros/Util.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Util.scala
@@ -21,6 +21,11 @@ class Util(val c: blackbox.Context) extends Common {
     }
   }
 
+  def strideOf[T: WeakTypeTag] = {
+    val T = wt[T]
+    q"???"
+  }
+
   def alignmentOf_[T: WeakTypeTag]      = q"${alignmentOf(wt[T])}"
   def alignmentOfEmbed_[T: WeakTypeTag] = q"${alignmentOfEmbed(wt[T])}"
   def sizeOf_[T: WeakTypeTag]           = q"${sizeOf(wt[T])}"

--- a/macros/src/main/scala/offheap/internal/macros/Util.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Util.scala
@@ -21,8 +21,8 @@ class Util(val c: blackbox.Context) extends Common {
     }
   }
 
-  def alignmentOf_[T: WeakTypeTag]     = q"${alignmentOf(wt[T])}"
-  def alignmentOfData_[T: WeakTypeTag] = q"${alignmentOfData(wt[T])}"
-  def sizeOf_[T: WeakTypeTag]          = q"${sizeOf(wt[T])}"
-  def sizeOfData_[T: WeakTypeTag]      = q"${sizeOfData(wt[T])}"
+  def alignmentOf_[T: WeakTypeTag]      = q"${alignmentOf(wt[T])}"
+  def alignmentOfEmbed_[T: WeakTypeTag] = q"${alignmentOfEmbed(wt[T])}"
+  def sizeOf_[T: WeakTypeTag]           = q"${sizeOf(wt[T])}"
+  def sizeOfEmbed_[T: WeakTypeTag]      = q"${sizeOfEmbed(wt[T])}"
 }

--- a/macros/src/main/scala/offheap/internal/macros/Util.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Util.scala
@@ -21,9 +21,11 @@ class Util(val c: blackbox.Context) extends Common {
     }
   }
 
-  def strideOf[T: WeakTypeTag] = {
-    val T = wt[T]
-    q"???"
+  def strideOf_[T: WeakTypeTag] = wt[T] match {
+    case ArrayOf(tpe, isEmbed) =>
+      q"${strideOf(tpe, isEmbed)}"
+    case _ =>
+      abort("given type must be an an offheap array.")
   }
 
   def alignmentOf_[T: WeakTypeTag]      = q"${alignmentOf(wt[T])}"

--- a/tests/src/test/scala/ArrayStrideSuite.scala
+++ b/tests/src/test/scala/ArrayStrideSuite.scala
@@ -1,0 +1,22 @@
+package test
+
+import org.scalatest.FunSuite
+import offheap._
+
+@data class AS1(a: Long, b: Byte)
+@data class AS2(a: Int, b: Int)
+@data class AS3(a: Byte, b: Short)
+
+class ArrayStrideSuite extends FunSuite {
+  test("strideOf[Array[Byte]]")   { assert(strideOf[Array[Byte]]   == 1) }
+  test("strideOf[Array[Char]]")   { assert(strideOf[Array[Char]]   == 2) }
+  test("strideOf[Array[Short]]")  { assert(strideOf[Array[Short]]  == 2) }
+  test("strideOf[Array[Int]]")    { assert(strideOf[Array[Int]]    == 4) }
+  test("strideOf[Array[Long]]")   { assert(strideOf[Array[Long]]   == 8) }
+  test("strideOf[Array[Float]]")  { assert(strideOf[Array[Float]]  == 4) }
+  test("strideOf[Array[Double]]") { assert(strideOf[Array[Double]] == 8) }
+
+  test("strideOf[EmbedArray[AS1]]") { assert(strideOf[EmbedArray[AS1]] == 16) }
+  test("strideOf[EmbedArray[AS2]]") { assert(strideOf[EmbedArray[AS2]] == 8)  }
+  test("strideOf[EmbedArray[AS3]]") { assert(strideOf[EmbedArray[AS3]] == 4)  }
+}

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -4,6 +4,7 @@ import org.scalatest.FunSuite
 import offheap._
 
 @data class EPoint(x: Int, y: Int)
+@data class EContainer(arr: EmbedArray[EPoint])
 
 class EmbedArraySuite extends FunSuite {
   implicit val alloc = Allocator()
@@ -64,5 +65,12 @@ class EmbedArraySuite extends FunSuite {
 
   test("empty is empty") {
     EmbedArray.empty[EPoint].isEmpty
+  }
+
+  test("embed array as a field") {
+    val container = EContainer(EmbedArray(EPoint(10, 20)))
+    assert(container.arr.nonEmpty)
+    assert(container.arr(0).x == 10)
+    assert(container.arr(0).y == 20)
   }
 }

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -1,0 +1,68 @@
+package test
+
+import org.scalatest.FunSuite
+import offheap._
+
+@data class EPoint(x: Int, y: Int)
+
+class EmbedArraySuite extends FunSuite {
+  implicit val alloc = Allocator()
+
+  test("uninit") {
+    val arr = EmbedArray.uninit[EPoint](2)
+    val p1 = arr(0)
+    p1.x + p1.y
+    val p2 = arr(1)
+    p2.x + p2.y
+  }
+
+  test("vararg") {
+    val arr = EmbedArray(EPoint(10, 20), EPoint(30, 40))
+    assert(arr(0).x == 10)
+    assert(arr(0).y == 20)
+    assert(arr(1).x == 30)
+    assert(arr(1).y == 40)
+  }
+
+  test("fill") {
+    var i = 0
+    val arr = EmbedArray.fill[EPoint](10) {
+      val res = EPoint(i, i)
+      i += 1
+      res
+    }
+    for (j <- 0 to 9) {
+      assert(arr(j).x == j)
+      assert(arr(j).y == j)
+    }
+  }
+
+  test("map") {
+    val arr = EmbedArray(EPoint(10, 20), EPoint(30, 40))
+    val narr = arr.map { p => p.copy(x = p.x * 2, y = p.y / 10) }
+    assert(narr(0).x == 20)
+    assert(narr(0).y == 2)
+    assert(narr(1).x == 60)
+    assert(narr(1).y == 4)
+  }
+
+  test("out of bounds") {
+    val arr = EmbedArray.uninit[EPoint](10)
+    intercept[IndexOutOfBoundsException] { arr(-1) }
+    intercept[IndexOutOfBoundsException] { arr(10) }
+  }
+
+  test("copy") {
+    val dst = EmbedArray.uninit[EPoint](3)
+    val src = EmbedArray(EPoint(1, 2), EPoint(2, 3), EPoint(3, 4))
+    EmbedArray.copy(src, 0, dst, 0, 3)
+    for (i <- 0 to 2) {
+      assert(dst(i).x == src(i).x)
+      assert(dst(i).y == src(i).y)
+    }
+  }
+
+  test("empty is empty") {
+    EmbedArray.empty[EPoint].isEmpty
+  }
+}

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -5,6 +5,7 @@ import offheap._
 
 @data class EPoint(x: Int, y: Int)
 @data class EContainer(arr: EmbedArray[EPoint])
+@data class ECell(var v: Int)
 
 class EmbedArraySuite extends FunSuite {
   implicit val alloc = Allocator()
@@ -72,5 +73,15 @@ class EmbedArraySuite extends FunSuite {
     assert(container.arr.nonEmpty)
     assert(container.arr(0).x == 10)
     assert(container.arr(0).y == 20)
+  }
+
+  test("new data is copied over") {
+    val cell = ECell(3)
+    val arr = EmbedArray(cell)
+    assert(arr(0).v == 3)
+    cell.v = 4
+    assert(arr(0).v == 3)
+    arr(0) = cell
+    assert(arr(0).v == 4)
   }
 }

--- a/tests/src/test/scala/LayoutSuite.scala
+++ b/tests/src/test/scala/LayoutSuite.scala
@@ -38,23 +38,23 @@ class LayoutSuite extends FunSuite {
   test("L6.emb offset") { assert(offsetOf[L6]("emb") == 8) }
   test("L8.emb offset") { assert(offsetOf[L8]("emb") == 4) }
 
-  test("sizeOfData[L1]") { assert(sizeOfData[L1] == 2 ) }
-  test("sizeOfData[L2]") { assert(sizeOfData[L2] == 4 ) }
-  test("sizeOfData[L3]") { assert(sizeOfData[L3] == 8 ) }
-  test("sizeOfData[L4]") { assert(sizeOfData[L4] == 16) }
-  test("sizeOfData[L5]") { assert(sizeOfData[L5] == 16) }
-  test("sizeOfData[L6]") { assert(sizeOfData[L6] == 24) }
-  test("sizeOfData[L7]") { assert(sizeOfData[L7] == 6) }
-  test("sizeOfData[L8]") { assert(sizeOfData[L8] == 24) }
-  test("sizeOfData[L9]") { assert(sizeOfData[L9] == 1) }
+  test("sizeOfEmbed[L1]") { assert(sizeOfEmbed[L1] == 2 ) }
+  test("sizeOfEmbed[L2]") { assert(sizeOfEmbed[L2] == 4 ) }
+  test("sizeOfEmbed[L3]") { assert(sizeOfEmbed[L3] == 8 ) }
+  test("sizeOfEmbed[L4]") { assert(sizeOfEmbed[L4] == 16) }
+  test("sizeOfEmbed[L5]") { assert(sizeOfEmbed[L5] == 16) }
+  test("sizeOfEmbed[L6]") { assert(sizeOfEmbed[L6] == 24) }
+  test("sizeOfEmbed[L7]") { assert(sizeOfEmbed[L7] == 6) }
+  test("sizeOfEmbed[L8]") { assert(sizeOfEmbed[L8] == 24) }
+  test("sizeOfEmbed[L9]") { assert(sizeOfEmbed[L9] == 1) }
 
-  test("alignmentOfData[L1]") { assert(alignmentOfData[L1] == 1) }
-  test("alignmentOfData[L2]") { assert(alignmentOfData[L2] == 2) }
-  test("alignmentOfData[L3]") { assert(alignmentOfData[L3] == 4) }
-  test("alignmentOfData[L4]") { assert(alignmentOfData[L4] == 8) }
-  test("alignmentOfData[L5]") { assert(alignmentOfData[L5] == 8) }
-  test("alignmentOfData[L6]") { assert(alignmentOfData[L6] == 8) }
-  test("alignmentOfData[L7]") { assert(alignmentOfData[L7] == 4) }
-  test("alignmentOfData[L8]") { assert(alignmentOfData[L8] == 8) }
-  test("alignmentOfData[L9]") { assert(alignmentOfData[L9] == 1) }
+  test("alignmentOfEmbed[L1]") { assert(alignmentOfEmbed[L1] == 1) }
+  test("alignmentOfEmbed[L2]") { assert(alignmentOfEmbed[L2] == 2) }
+  test("alignmentOfEmbed[L3]") { assert(alignmentOfEmbed[L3] == 4) }
+  test("alignmentOfEmbed[L4]") { assert(alignmentOfEmbed[L4] == 8) }
+  test("alignmentOfEmbed[L5]") { assert(alignmentOfEmbed[L5] == 8) }
+  test("alignmentOfEmbed[L6]") { assert(alignmentOfEmbed[L6] == 8) }
+  test("alignmentOfEmbed[L7]") { assert(alignmentOfEmbed[L7] == 4) }
+  test("alignmentOfEmbed[L8]") { assert(alignmentOfEmbed[L8] == 8) }
+  test("alignmentOfEmbed[L9]") { assert(alignmentOfEmbed[L9] == 1) }
 }


### PR DESCRIPTION
Here we introduce an equivalent of field embedding (https://github.com/densh/scala-offheap/pull/34) only for arrays. Unlike regular arrays embedded arrays have object values stored inside of the array rather than references to objects allocated elsewhere. This is direct equivalent of array of structs in C. 