### PR TITLE
Move memory to top-level package

### DIFF
--- a/core/src/main/scala/offheap/Memory.java
+++ b/core/src/main/scala/offheap/Memory.java
@@ -1,26 +1,9 @@
 package offheap.internal;
 
-import sun.misc.Unsafe;
-import java.lang.reflect.Field;
 import static offheap.internal.Sanitizer.validate;
+import static offheap.internal.SunMisc.UNSAFE;
 
 public class Memory {
-    public static final Unsafe UNSAFE;
-    static {
-        Unsafe value = null;
-        try {
-            value = Unsafe.getUnsafe();
-        } catch (SecurityException e) {
-            try {
-                Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                f.setAccessible(true);
-                value = (Unsafe) f.get(null);
-            } catch (NoSuchFieldException nsfe) {
-            } catch (IllegalAccessException iae) {
-            }
-        }
-        UNSAFE = value;
-    }
     public static long allocate(long size) {
         return UNSAFE.allocateMemory(size);
     }

--- a/core/src/main/scala/offheap/Pool.scala
+++ b/core/src/main/scala/offheap/Pool.scala
@@ -1,7 +1,7 @@
 package offheap
 
 import offheap.internal.Sanitizer
-import offheap.internal.Memory.UNSAFE
+import offheap.internal.SunMisc.UNSAFE
 
 /** Efficient pool of fixed-size memory pages.
  *  Allocations from underlying allocator are performed

--- a/core/src/main/scala/offheap/internal/Sanitizer.scala
+++ b/core/src/main/scala/offheap/internal/Sanitizer.scala
@@ -2,7 +2,7 @@ package offheap
 package internal
 
 import java.{lang => jl}
-import internal.Memory.UNSAFE
+import internal.SunMisc.UNSAFE
 
 object Sanitizer {
   private[this] final val UNPACKED_ID_MASK = 65535L

--- a/core/src/main/scala/offheap/internal/SunMisc.java
+++ b/core/src/main/scala/offheap/internal/SunMisc.java
@@ -1,0 +1,23 @@
+package offheap.internal;
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+
+public class SunMisc {
+    public static final Unsafe UNSAFE;
+    static {
+        Unsafe value = null;
+        try {
+            value = Unsafe.getUnsafe();
+        } catch (SecurityException e) {
+            try {
+                Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                value = (Unsafe) f.get(null);
+            } catch (NoSuchFieldException nsfe) {
+            } catch (IllegalAccessException iae) {
+            }
+        }
+        UNSAFE = value;
+    }
+}

--- a/core/src/main/scala/offheap/malloc.scala
+++ b/core/src/main/scala/offheap/malloc.scala
@@ -1,6 +1,6 @@
 package offheap
 
-import offheap.internal.Memory.UNSAFE
+import offheap.internal.SunMisc.UNSAFE
 
 /** Underyling OS allocator that does not attempt
  *  to perform any automatic memory management

--- a/jmh/src/main/scala/Array.scala
+++ b/jmh/src/main/scala/Array.scala
@@ -3,7 +3,7 @@ package offheap.test.jmh
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
 import java.util.concurrent.TimeUnit
-import offheap._, internal.Memory.UNSAFE
+import offheap._, internal.SunMisc.UNSAFE
 
 @State(Scope.Thread)
 class Array {

--- a/jmh/src/main/scala/LoopBench.scala
+++ b/jmh/src/main/scala/LoopBench.scala
@@ -1,7 +1,7 @@
 package offheap.test.jmh
 
 import org.openjdk.jmh.annotations._
-import offheap._, internal.Memory.UNSAFE
+import offheap._, internal.SunMisc.UNSAFE
 
 @State(Scope.Thread)
 class LoopBench {


### PR DESCRIPTION
Now that we have direct access to addr and malloc,
it's only logical to also expose memory as an (unsafe)
part of api.