### PR TITLE
IntelliJ plugin and minor changes to satisfy it

### DIFF
--- a/core/src/main/scala/offheap/Annotations.scala
+++ b/core/src/main/scala/offheap/Annotations.scala
@@ -2,7 +2,7 @@ package scala.offheap
 
 import scala.language.experimental.{macros => CanMacro}
 import scala.annotation.StaticAnnotation
-import offheap.internal.macros
+import scala.offheap.internal.macros
 
 /** Macro annotation that transforms given class into
  *  case-class-like offheap class.

--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -1,7 +1,7 @@
 package scala.offheap
 
 import scala.language.experimental.{macros => CanMacro}
-import offheap.internal.macros
+import scala.offheap.internal.macros
 
 /** Off-heap equivalent of `scala.Array`. Can only be used
  *  with statically known values of type parameter which also

--- a/core/src/main/scala/offheap/EmbedArray.scala
+++ b/core/src/main/scala/offheap/EmbedArray.scala
@@ -1,7 +1,7 @@
 package scala.offheap
 
 import scala.language.experimental.{macros => CanMacro}
-import offheap.internal.macros
+import scala.offheap.internal.macros
 
 /** An alternative implemenation of an array that inlines
  *  allocation of given offheap class into the array layout.

--- a/core/src/main/scala/offheap/Pool.scala
+++ b/core/src/main/scala/offheap/Pool.scala
@@ -1,7 +1,7 @@
 package scala.offheap
 
-import offheap.internal.Sanitizer
-import offheap.internal.SunMisc.UNSAFE
+import scala.offheap.internal.Sanitizer
+import scala.offheap.internal.SunMisc.UNSAFE
 
 /** Efficient pool of fixed-size memory pages.
  *  Allocations from underlying allocator are performed

--- a/core/src/main/scala/offheap/Region.scala
+++ b/core/src/main/scala/offheap/Region.scala
@@ -1,9 +1,9 @@
 package scala.offheap
 
 import scala.language.experimental.{macros => canMacro}
-import offheap.internal.macros
-import offheap.internal.Sanitizer
-import offheap.internal.Checked
+import scala.offheap.internal.macros
+import scala.offheap.internal.Sanitizer
+import scala.offheap.internal.Checked
 
 /** Family of scoped memory allocators. Allocated memory
  *  is available as long as execution is still in given

--- a/core/src/main/scala/offheap/malloc.scala
+++ b/core/src/main/scala/offheap/malloc.scala
@@ -1,6 +1,6 @@
 package scala.offheap
 
-import offheap.internal.SunMisc.UNSAFE
+import scala.offheap.internal.SunMisc.UNSAFE
 
 /** Underyling OS allocator that does not attempt
  *  to perform any automatic memory management

--- a/core/src/main/scala/offheap/package.scala
+++ b/core/src/main/scala/offheap/package.scala
@@ -1,7 +1,7 @@
 package scala
 
 import scala.language.experimental.{ macros => canMacro }
-import offheap.internal.macros
+import scala.offheap.internal.macros
 
 package object offheap {
   /** Physical address representation.

--- a/jmh/src/main/scala/Access.scala
+++ b/jmh/src/main/scala/Access.scala
@@ -1,7 +1,7 @@
 package jmh
 
 import org.openjdk.jmh.annotations._
-import offheap._
+import scala.offheap._
 
 class JByteCell(var v: Byte)
 class JShortCell(var v: Short)

--- a/jmh/src/main/scala/Allocation.scala
+++ b/jmh/src/main/scala/Allocation.scala
@@ -2,7 +2,7 @@ package jmh
 
 import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
-import offheap._
+import scala.offheap._
 
 class JAlloc8(val a: Long)
 class JAlloc16(val a: Long, val b: Long)

--- a/jmh/src/main/scala/Array.scala
+++ b/jmh/src/main/scala/Array.scala
@@ -3,7 +3,8 @@ package jmh
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
 import java.util.concurrent.TimeUnit
-import offheap._, internal.SunMisc.UNSAFE
+import scala.offheap._
+import scala.offheap.internal.SunMisc.UNSAFE
 
 @State(Scope.Thread)
 class Array {

--- a/jmh/src/main/scala/BinaryTree.scala
+++ b/jmh/src/main/scala/BinaryTree.scala
@@ -1,7 +1,7 @@
 package jmh
 
 import org.openjdk.jmh.annotations._
-import offheap._
+import scala.offheap._
 
 @State(Scope.Thread)
 class GCBinaryTree {

--- a/jmh/src/main/scala/LoopBench.scala
+++ b/jmh/src/main/scala/LoopBench.scala
@@ -1,7 +1,8 @@
 package jmh
 
 import org.openjdk.jmh.annotations._
-import offheap._, internal.SunMisc.UNSAFE
+import scala.offheap._
+import scala.offheap.internal.SunMisc.UNSAFE
 
 @State(Scope.Thread)
 class LoopBench {

--- a/jmh/src/main/scala/Pool.scala
+++ b/jmh/src/main/scala/Pool.scala
@@ -1,7 +1,7 @@
 package jmh
 
 import org.openjdk.jmh.annotations._
-import offheap._
+import scala.offheap._
 
 @State(Scope.Thread)
 class PoolContention {

--- a/jmh/src/main/scala/Region.scala
+++ b/jmh/src/main/scala/Region.scala
@@ -2,7 +2,7 @@ package jmh
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
-import offheap._
+import scala.offheap._
 
 @State(Scope.Thread)
 class RegionClose {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object RegionsBuild extends Build {
     organization := "sh.den",
     resolvers += Resolver.sonatypeRepo("snapshots"),
     resolvers += Resolver.sonatypeRepo("releases"),
-    initialCommands in console += "import offheap._; implicit val alloc = malloc",
+    initialCommands in console += "import scala.offheap._; implicit val alloc = malloc",
     addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full),
     publishMavenStyle := true,
     publishOnlyWhenOnMaster := publishOnlyWhenOnMasterImpl.value,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.14")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/sandbox/sandbox.scala
+++ b/sandbox/sandbox.scala
@@ -1,2 +1,2 @@
 package test
-import offheap._
+import scala.offheap._

--- a/tests/src/test/scala/ArrayStrideSuite.scala
+++ b/tests/src/test/scala/ArrayStrideSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class AS1(a: Long, b: Byte)
 @data class AS2(a: Int, b: Int)

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class ArrayContainer(var arr: Array[Int])
 

--- a/tests/src/test/scala/DataSuite.scala
+++ b/tests/src/test/scala/DataSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class Point(x: Double, y: Double) {
   def distanceTo(other: Point): Double =

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class EPoint(x: Int, y: Int)
 @data class EContainer(arr: EmbedArray[EPoint])

--- a/tests/src/test/scala/EmbedSuite.scala
+++ b/tests/src/test/scala/EmbedSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class Inner(var v: Int)
 @data class Outer(@embed var inner: Inner)

--- a/tests/src/test/scala/EnumSuite.scala
+++ b/tests/src/test/scala/EnumSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 import E1._, E2._
 
 @enum class E1

--- a/tests/src/test/scala/LayoutSuite.scala
+++ b/tests/src/test/scala/LayoutSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class L1(x: Byte, y: Byte)
 @data class L2(x: Byte, y: Short)

--- a/tests/src/test/scala/MutableSuite.scala
+++ b/tests/src/test/scala/MutableSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class C1(var x: Int)
 

--- a/tests/src/test/scala/PackingSuite.scala
+++ b/tests/src/test/scala/PackingSuite.scala
@@ -4,7 +4,7 @@ import java.{lang => jl}
 import org.scalacheck.Gen
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
-import offheap.internal.Sanitizer._
+import scala.offheap.internal.Sanitizer._
 
 class PackingSuite extends Properties("Packing") {
   val ADDR_MASK = jl.Long.MAX_VALUE >> 16

--- a/tests/src/test/scala/RegionSuite.scala
+++ b/tests/src/test/scala/RegionSuite.scala
@@ -1,7 +1,7 @@
 package test
 
 import org.scalatest.FunSuite
-import offheap._
+import scala.offheap._
 
 @data class Dummy(value: Int)
 


### PR DESCRIPTION
Apparently it can't figure out that `import offheap._` is the same as `import scala.offheap._`.

/cc @ignasi35 @arosenberger