### PR TITLE
Add support for reallocate and free for regions

### DIFF
--- a/core/src/main/scala/offheap/Allocator.scala
+++ b/core/src/main/scala/offheap/Allocator.scala
@@ -1,12 +1,8 @@
 package scala.offheap
 
-/** An off-heap memory allocator. Must always implement
- *  `allocate` method. `reallocate` and `free` may not
- *  throw `UnsupportedOperationException` for automatically
- *  managed allocators like regions.
- */
+/** An off-heap memory allocator. */
 trait Allocator {
   def allocate(size: Size): Addr
-  def reallocate(addr: Addr, size: Size): Addr
+  def reallocate(oldAddr: Addr, oldSize: Size, newSize: Size): Addr
   def free(addr: Addr): Unit
 }

--- a/core/src/main/scala/offheap/Exceptions.scala
+++ b/core/src/main/scala/offheap/Exceptions.scala
@@ -11,3 +11,7 @@ class InaccessibleMemoryException(reason: String = "") extends Exception(reason)
 
 /** An exception that is thrown when safe `as[T]` cast fails. */
 class CastException(reason: String = "") extends Exception(reason)
+
+/** An exception that is thrown whenever one tries to call methods of the closed region. */
+class RegionClosedException(region: Region)
+  extends Exception(s"$region has already been closed")

--- a/core/src/main/scala/offheap/Pool.scala
+++ b/core/src/main/scala/offheap/Pool.scala
@@ -42,13 +42,8 @@ final class Pool(
   }
   protected override def finalize: Unit = {
     while (chunk != null) {
-      try {
-        alloc.free(chunk.start)
-        chunk = chunk.next
-      } catch {
-        case _: UnsupportedOperationException =>
-          chunk = null
-      }
+      alloc.free(chunk.start)
+      chunk = chunk.next
     }
   }
   def claim(): Pool.Page = this.synchronized {

--- a/core/src/main/scala/offheap/malloc.scala
+++ b/core/src/main/scala/offheap/malloc.scala
@@ -7,7 +7,10 @@ import scala.offheap.internal.SunMisc.UNSAFE
  *  (all allocations must have accompanied calls to free.)
  */
 object malloc extends Allocator {
-  def allocate(size: Size): Addr               = UNSAFE.allocateMemory(size)
-  def reallocate(addr: Addr, size: Size): Addr = UNSAFE.reallocateMemory(addr, size)
-  def free(addr: Addr): Unit                   = UNSAFE.freeMemory(addr)
+  def allocate(size: Size): Addr =
+    UNSAFE.allocateMemory(size)
+  def reallocate(oldAddr: Addr, oldSize: Size, newSize: Size): Addr =
+    UNSAFE.reallocateMemory(oldAddr, newSize)
+  def free(addr: Addr): Unit =
+    UNSAFE.freeMemory(addr)
 }


### PR DESCRIPTION
Those two don't attempt to perform any deallocation but
rather just delay the clean-up until the region is closed.

Previous behaviour of throwing an exception wasn't quite
useful as one had to effectively always special case
two types of allocators for any allocator-generic code.

Additionally this introduces a new exception to replace
IllegalArgumentException when a method on a closed region
is being called.

Review by @arosenberger 