### PR TITLE
Renames @enum into @variant

### DIFF
--- a/core/src/main/scala/offheap/Annotations.scala
+++ b/core/src/main/scala/offheap/Annotations.scala
@@ -17,9 +17,9 @@ final class data extends StaticAnnotation {
  *  off-heap classes defined in its companion form an
  *  off-heap child-parent relationship.
  */
-final class enum extends StaticAnnotation {
+final class variant extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any =
-    macro macros.Annotations.enum
+    macro macros.Annotations.variant
 }
 
 /** Annotation that marks fields as embedded.

--- a/docs/00_toc.md
+++ b/docs/00_toc.md
@@ -5,7 +5,7 @@
     * Supported environments
 1. [Off-heap classes](/docs/02_off-heap_classes.md)
     * `@data` classes
-    * `@enum` classes
+    * `@variant` classes
 1. [Off-heap arrays](/docs/03_off-heap_arrays.md)
     * `Array[T]`
     * `EmbedArray[T]`

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -15,7 +15,7 @@ addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion
 
 This includes scala-offheap's latest snapshot release and current (as of this writing)
 release of macro paradise. Macro paradise is only necessary to expand `@data` and
-`@enum` annotations and can be omitted if those features are not used.
+`@variant` annotations and can be omitted if those features are not used.
 
 Example sbt project with simple setup is
 [available on github](https://github.com/densh/scala-offheap-example).

--- a/docs/02_off-heap_classes.md
+++ b/docs/02_off-heap_classes.md
@@ -15,7 +15,7 @@ scala> implicit val alloc: Allocator = malloc
 alloc: offheap.Allocator = offheap.malloc$@23d230db
 ```
 
-Off-heap classes come in two varieties: `@data` classes and `@enum` classes. Both of
+Off-heap classes come in two varieties: `@data` classes and `@variant` classes. Both of
 them desugar down to value classes over underlying physical address. Due to that they:
 
 * can only be defined in statically accessible locations
@@ -171,12 +171,12 @@ and macros that are used to implement them:
 * Data classes may not have fields that refer to on-heap classes
   (i.e. all fields should either be of primitive or off-heap object types.)
 
-## @enum classes
+## @variant classes
 
-Enum classes are an off-heap equivalent of sealed abstract class hierarchy. For example:
+Variant classes are an off-heap equivalent of sealed abstract class hierarchy. For example:
 
 ```scala
-@enum class Figure
+@variant class Figure
 object Figure {
   @data class Point(x: Float, y: Float)
   @data class Segment(from: Point, to: Point)
@@ -184,17 +184,17 @@ object Figure {
 }
 ```
 
-It's also possible to nest enums.
+It's also possible to nest variants:
 
 ```scala
-@enum class Figure
+@variant class Figure
 object Figure {
-  @enum class _2D
+  @variant class _2D
   object _2D {
     @data class Point(x: Float, y: Float)
     ...
   }
-  @enum class _3D
+  @variant class _3D
   object _3D {
     @data class Point(x: Float, y: Float, z: Float)
     ...
@@ -203,15 +203,15 @@ object Figure {
 ```
 
 
-Whenever inner enum doesn't define any methods it's possible to use shorthand syntax
-that annotates nested object as `@enum` without a need to explicitly define accompanying
+Whenever inner variant doesn't define any methods it's possible to use shorthand syntax
+that annotates nested object as `@variant` without a need to explicitly define accompanying
 class (it will be generated automatically):
 
 ```scala
-@enum class Figure
+@variant class Figure
 object Figure {
-  @enum object _2D { ... }
-  @enum object _3D { ... }
+  @variant object _2D { ... }
+  @variant object _3D { ... }
 }
 ```
 
@@ -221,8 +221,8 @@ numeric type appropriate to enumerate all nested classes) to each and every chil
 data class.
 
 This field is used to implement pattern matching and `is` and `as` helpers. In situations
-when enum classes are nested one into the other, the hidden tag field is introduced only
-once per top-level enum class. Nested enum classes share the same field.
+when variant classes are nested one into the other, the hidden tag field is introduced only
+once per top-level variant class. Nested variant classes share the same field.
 
 **Automatically generated members.** Enum classes generates a subset of methods
 we've seen before with the same semantics as in data classes:

--- a/docs/06_faq.md
+++ b/docs/06_faq.md
@@ -13,6 +13,6 @@ be affected by the change.
 **Q**: Macro annotations are an experimental feature, what will happen if they are not merged into
 mainline Scala and become unsupported?
 
-**A**: In that case we'll re-implement the same functionality (namely `@data` and `@enum` annotations)
+**A**: In that case we'll re-implement the same functionality (namely `@data` and `@variant` annotations)
 using lower-level compiler plugin infrastructure. Considering that macros share reflection APIs with
 the compiler most of the code can be re-used.

--- a/macros/src/main/scala/offheap/internal/macros/Method.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Method.scala
@@ -87,7 +87,7 @@ class Method(val c: blackbox.Context) extends Common {
             case ..$cases
             case unknown =>
               throw new $IllegalArgumentExceptionClass(
-                "Unknown branch of enumeration with tag " + unknown)
+                "Unknown case of variant with tag " + unknown)
           }
       """
     } else unreachable

--- a/tests/src/test/scala/VariantSuite.scala
+++ b/tests/src/test/scala/VariantSuite.scala
@@ -4,10 +4,10 @@ import org.scalatest.FunSuite
 import scala.offheap._
 import E1._, E2._
 
-@enum class E1
+@variant class E1
 object E1 {
   @data class D1
-  @enum object E2 {
+  @variant object E2 {
     @data class D2
   }
   @data class D3
@@ -20,7 +20,7 @@ object Response {
   @data class Fail
 }
 import Response._
-@enum class Response {
+@variant class Response {
   def map(f: Int => Int)(implicit alloc: Allocator): Response = this match {
     case Success(value) => Success(f(value))
     case Fail()         => this
@@ -32,7 +32,7 @@ import Response._
 }
 
 
-class EnumSuite extends FunSuite {
+class VariantSuite extends FunSuite {
   implicit val alloc = malloc
 
   test("D1 is D1") { assert(D1().is[D1]) }


### PR DESCRIPTION
We might introduce C interop in the future and name clash
between C enums and our tagged unions was quite unfortunate.
We rename @enum to @variant to avoid this.