### PR TITLE
Add support for Array.sameElements

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -24,6 +24,7 @@ final class Array[A] private (val addr: Addr) extends AnyVal {
             (implicit a: Allocator): Array[A]            = macro macros.ArrayApi.filter
   def forall(f: A => Boolean): Boolean                   = macro macros.ArrayApi.forall
   def exists(f: A => Boolean): Boolean                   = macro macros.ArrayApi.exists
+  def sameElements(other: Array[A]): Boolean             = macro macros.ArrayApi.sameElements
   def toArray: scala.Array[A]                            = macro macros.ArrayApi.toArray
   def clone(implicit a: Allocator): Array[A]             = macro macros.ArrayApi.clone_
 

--- a/core/src/main/scala/offheap/Pool.scala
+++ b/core/src/main/scala/offheap/Pool.scala
@@ -8,7 +8,7 @@ import scala.offheap.internal.SunMisc.UNSAFE
  *  in big chunks of memory that are sliced into
  *  pages of requested size.
  *
- *  Pages and chunks are organized in a intrusive linked list
+ *  Pages and chunks are organized in an intrusive linked list
  *  way to minimise memory overhead and re-use the same nodes
  *  for the whole lifetime of the pool.
  *

--- a/core/src/main/scala/offheap/internal/Annotations.scala
+++ b/core/src/main/scala/offheap/internal/Annotations.scala
@@ -9,7 +9,7 @@ final class Parent(tag: Class[_]) extends StaticAnnotation
 final class PotentialChildren(tags: Class[_]*) extends StaticAnnotation
 final class ClassTag(tag: Any) extends StaticAnnotation
 final class ClassTagRange(from: Any, to: Any) extends StaticAnnotation // > from <= to
-final class ParentExractor(tag: Class[_], value: Any) extends StaticAnnotation
+final class ParentExtractor(tag: Class[_], value: Any) extends StaticAnnotation
 final class PrimaryExtractor(value: Any) extends StaticAnnotation
 final class UniversalExtractor(value: Any) extends StaticAnnotation
 final class Field[T](name: String, after: Any,

--- a/docs/02_off-heap_classes.md
+++ b/docs/02_off-heap_classes.md
@@ -34,7 +34,7 @@ Data classes are a close equivalent of on-heap case classes. For example:
 ```
 
 Defines a data class with two immutable publicly accessible fields `x` and `y`. Data
-classes are usually passed by reference just regular normal classes. For example if
+classes are usually passed by reference just like regular classes. For example if
 we define another data class that contains two fields of `Point` type:
 
 ```scala
@@ -100,7 +100,7 @@ defined class XYZ
 defined object XYZ
 ```
 
-Is going to take 16 bytes, not 9. 1-byte padding is going to be inserted after `x` and
+Is going to take 16 bytes, not 11. 1-byte padding is going to be inserted after `x` and
 4-byte padding is going to be inserted after `y`. Reordering the fields can sometimes
 reduce the size of the data structure.
 

--- a/docs/03_off-heap_arrays.md
+++ b/docs/03_off-heap_arrays.md
@@ -23,6 +23,7 @@ stored as `Addr` references.
 * `arr.forall(f)`. Check if given predicate applies to all elements in the array.
 * `arr.exists(f)`. Check if given predicate applies to at least one element in the array.
 * `arr.filter(f)`. Create a new array where each element satifies given predicate.
+* `arr.sameElements(other)`. Check if this and given array have the same elements in the same order.
 
 **Companion methods.**
 
@@ -51,7 +52,8 @@ An alternative implementation of arrays that includes off-heap classes as values
 than as references to reduce dereferencing overhead and improve data locality.
 Direct equivalent of dynamically sized array of structs in C.
 
-**Methods.** Same as for regular arrays.
+**Methods.** Same as for regular arrays, except for the methods which rely on equality of
+elements like `sameElements`.
 
 **Companion methods.** Same as for regular arrays.
 

--- a/macros/src/main/scala/offheap/internal/macros/Definitions.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Definitions.scala
@@ -29,7 +29,7 @@ trait Definitions {
   val PotentialChildrenClass  = staticClass("scala.offheap.internal.PotentialChildren")
   val ParentClass             = staticClass("scala.offheap.internal.Parent")
   val PrimaryExtractorClass   = staticClass("scala.offheap.internal.PrimaryExtractor")
-  val ParentExtractorClass    = staticClass("scala.offheap.internal.ParentExractor")
+  val ParentExtractorClass    = staticClass("scala.offheap.internal.ParentExtractor")
   val UniversalExtractorClass = staticClass("scala.offheap.internal.UniversalExtractor")
   val FieldClass              = staticClass("scala.offheap.internal.Field")
   val AnnotsClass             = staticClass("scala.offheap.internal.Annots")

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -214,4 +214,19 @@ class ArraySuite extends FunSuite {
     assert(!Array.empty[Int].exists(_ < 10))
     assert(!Array.empty[Double].exists(_ => true))
   }
+
+  test("sameElements") {
+    var arr1 = Array(1, 3, 5, 7)
+    val arr2 = Array(1, 3, 5, 7)
+    val arr3 = Array(1, 3, 5, 8)
+    val arr4 = Array(1, 3, 5)
+
+    assert(arr1.sameElements(arr1))
+    assert(arr1.sameElements(arr2))
+    assert(!arr1.sameElements(arr3))
+    assert(!arr1.sameElements(arr4))
+    assert(!arr1.sameElements(Array.empty[Int]))
+    assert(!Array.empty[Int].sameElements(arr1))
+    assert(Array.empty[Int].sameElements(Array.empty[Int]))
+  }
 }

--- a/tests/src/test/scala/DataSuite.scala
+++ b/tests/src/test/scala/DataSuite.scala
@@ -20,7 +20,7 @@ class DataSuite extends FunSuite {
     assert(p.y == 20)
   }
 
-  test("acessors on empty throw null reference exception") {
+  test("accessors on empty throw null reference exception") {
     intercept[NullPointerException] {
       Point.empty.x
     }


### PR DESCRIPTION
Implements #82.

The method is implemented only for Arrays, since there is no way to check value equality between elements of a data class, so it doesn't make much sense to do it for EmbedArray.