### PR TITLE
Add support for Array.startsWith and Array.endsWith

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -25,6 +25,9 @@ final class Array[A] private (val addr: Addr) extends AnyVal {
   def forall(f: A => Boolean): Boolean                   = macro macros.ArrayApi.forall
   def exists(f: A => Boolean): Boolean                   = macro macros.ArrayApi.exists
   def sameElements(other: Array[A]): Boolean             = macro macros.ArrayApi.sameElements
+  def startsWith(that: Array[A]): Boolean                = macro macros.ArrayApi.startsWith
+  def startsWith(that: Array[A], offset: Int): Boolean   = macro macros.ArrayApi.startsWithOffset
+  def endsWith(that: Array[A]): Boolean                  = macro macros.ArrayApi.endsWith
   def toArray: scala.Array[A]                            = macro macros.ArrayApi.toArray
   def clone(implicit a: Allocator): Array[A]             = macro macros.ArrayApi.clone_
 

--- a/docs/03_off-heap_arrays.md
+++ b/docs/03_off-heap_arrays.md
@@ -24,6 +24,10 @@ stored as `Addr` references.
 * `arr.exists(f)`. Check if given predicate applies to at least one element in the array.
 * `arr.filter(f)`. Create a new array where each element satifies given predicate.
 * `arr.sameElements(other)`. Check if this and given array have the same elements in the same order.
+* `arr.startsWith(that)`. Check if this array starts with the same elements as the given array.
+* `arr.startsWith(that, offset)`. Check if this array starts with the same elements as the given array, 
+  starting at given offset.
+* `arr.endsWith(that)`. Check if this array ends with the same elements as the given array.
 
 **Companion methods.**
 

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -300,6 +300,76 @@ trait ArrayApiCommon extends ArrayCommon {
           """
       }
     }
+
+  def startsWith(that: Tree): Tree = startsWithOffset(that, q"0")
+
+  def startsWithOffset(that: Tree, offset: Tree): Tree = {
+    stabilized(c.prefix.tree) { pre =>
+      stabilized(that) { that =>
+        stabilized(offset) { offset =>
+          val index = freshVar("i", IntTpe, q"0")
+          val sourceLength = freshVal("srcLen", ArraySizeTpe, readSize(pre))
+          val thatLength = freshVal("thatLen", ArraySizeTpe, readSize(that))
+          val result = freshVar("result", BooleanTpe, q"true")
+          q"""
+            if ($offset < 0) ${throwOutOfBounds(offset)}
+
+            if ($pre.addr == $that.addr) true
+            else if ($pre.isEmpty) false
+            else if ($that.isEmpty) true
+            else {
+              $sourceLength
+              $thatLength
+              if ($offset + ${thatLength.symbol} > ${sourceLength.symbol}) false
+              else {
+                $index
+                $result
+                while (${result.symbol} && ${index.symbol} < ${thatLength.symbol}) {
+                  ${result.symbol} =
+                    ${readElem(pre, A, q"${index.symbol} + $offset")} == ${readElem(that, A, q"${index.symbol}")}
+                  ${index.symbol} += 1
+                }
+                ${result.symbol}
+              }
+            }
+          """
+        }
+      }
+    }
+  }
+
+  def endsWith(that: Tree) = {
+    stabilized(c.prefix.tree) { pre =>
+      stabilized(that) { that =>
+        val index = freshVar("i", IntTpe, q"0")
+        val sourceLength = freshVal("srcLen", ArraySizeTpe, readSize(pre))
+        val thatLength = freshVal("thatLen", ArraySizeTpe, readSize(that))
+        val offset = freshVal("offset", IntTpe, q"${sourceLength.symbol} - ${thatLength.symbol}")
+        val result = freshVar("result", BooleanTpe, q"true")
+        q"""
+          if ($pre.addr == $that.addr) true
+          else if ($pre.isEmpty) false
+          else if ($that.isEmpty) true
+          else {
+            $sourceLength
+            $thatLength
+            $offset
+            if (${offset.symbol} < 0 || ${offset.symbol} + ${thatLength.symbol} > ${sourceLength.symbol}) false
+            else {
+              $index
+              $result
+              while (${result.symbol} && ${index.symbol} < ${thatLength.symbol}) {
+                ${result.symbol} =
+                  ${readElem(pre, A, q"${index.symbol} + ${offset.symbol}")} == ${readElem(that, A, q"${index.symbol}")}
+                ${index.symbol} += 1
+              }
+              ${result.symbol}
+            }
+          }
+        """
+      }
+    }
+  }
 }
 
 trait ArrayModuleCommon extends ArrayCommon {

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -229,4 +229,37 @@ class ArraySuite extends FunSuite {
     assert(!Array.empty[Int].sameElements(arr1))
     assert(Array.empty[Int].sameElements(Array.empty[Int]))
   }
+
+  test("startsWith") {
+    val arr = Array(1, 3, 5, 7)
+    val arr2 = Array(1, 3)
+    val arr3 = Array(5, 7)
+    val arr4 = Array(1, 5)
+
+    assert(arr.startsWith(arr))
+    assert(arr.startsWith(arr2))
+    assert(arr.startsWith(arr3, 2))
+    assert(!arr.startsWith(arr3, 3))
+    assert(!arr.startsWith(arr4))
+    assert(!arr4.startsWith(arr))
+    assert(arr.startsWith(Array.empty[Int]))
+    assert(!Array.empty[Int].startsWith(arr))
+
+    intercept[IndexOutOfBoundsException] {
+      arr.startsWith(arr2, -1)
+    }
+  }
+
+  test("endsWith") {
+    val arr = Array(1, 3, 5, 7)
+    val arr2 = Array(3, 5, 7)
+    val arr3 = Array(1, 5)
+
+    assert(arr.endsWith(arr))
+    assert(arr.endsWith(arr2))
+    assert(!arr.endsWith(arr3))
+    assert(!arr3.endsWith(arr))
+    assert(arr.endsWith(Array.empty[Int]))
+    assert(!Array.empty[Int].endsWith(arr))
+  }
 }


### PR DESCRIPTION
Implements #81.

As with Array.sameElements, I think there is no point of having these methods for EmbedArray since its implementation is based on element equality.