### PR TITLE
Support inlining function literals with multiple arguments, implement Array.foldLeft and Array.foldRight

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -23,6 +23,8 @@ final class Array[A] private (val addr: Addr) extends AnyVal {
   def transform(f: A => A): Array[A]                     = macro macros.ArrayApi.transform
   def filter(f: A => Boolean)
             (implicit a: Allocator): Array[A]            = macro macros.ArrayApi.filter
+  def foldLeft[B](z: B, op: (B, A) => B): B              = macro macros.ArrayApi.foldLeft[B]
+  def foldRight[B](z: B, op: (A, B) => B): B             = macro macros.ArrayApi.foldRight[B]
   def forall(f: A => Boolean): Boolean                   = macro macros.ArrayApi.forall
   def exists(f: A => Boolean): Boolean                   = macro macros.ArrayApi.exists
   def sameElements(other: Array[A]): Boolean             = macro macros.ArrayApi.sameElements

--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -23,8 +23,8 @@ final class Array[A] private (val addr: Addr) extends AnyVal {
   def transform(f: A => A): Array[A]                     = macro macros.ArrayApi.transform
   def filter(f: A => Boolean)
             (implicit a: Allocator): Array[A]            = macro macros.ArrayApi.filter
-  def foldLeft[B](z: B, op: (B, A) => B): B              = macro macros.ArrayApi.foldLeft[B]
-  def foldRight[B](z: B, op: (A, B) => B): B             = macro macros.ArrayApi.foldRight[B]
+  def foldLeft[B](z: B)(op: (B, A) => B): B              = macro macros.ArrayApi.foldLeft[B]
+  def foldRight[B](z: B)(op: (A, B) => B): B             = macro macros.ArrayApi.foldRight[B]
   def forall(f: A => Boolean): Boolean                   = macro macros.ArrayApi.forall
   def exists(f: A => Boolean): Boolean                   = macro macros.ArrayApi.exists
   def sameElements(other: Array[A]): Boolean             = macro macros.ArrayApi.sameElements

--- a/core/src/main/scala/offheap/EmbedArray.scala
+++ b/core/src/main/scala/offheap/EmbedArray.scala
@@ -19,6 +19,8 @@ final class EmbedArray[A] private (val addr: Addr) extends AnyVal {
   def transform(f: A => A): EmbedArray[A]                     = macro macros.EmbedArrayApi.transform
   def filter(f: A => Boolean)
             (implicit a: Allocator): EmbedArray[A]            = macro macros.EmbedArrayApi.filter
+  def foldLeft[B](z: B, op: (B, A) => B): B                   = macro macros.EmbedArrayApi.foldLeft[B]
+  def foldRight[B](z: B, op: (A, B) => B): B                  = macro macros.EmbedArrayApi.foldRight[B]
   def forall(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.forall
   def exists(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.exists
   def toArray: scala.Array[A]                                 = macro macros.EmbedArrayApi.toArray

--- a/core/src/main/scala/offheap/EmbedArray.scala
+++ b/core/src/main/scala/offheap/EmbedArray.scala
@@ -19,8 +19,8 @@ final class EmbedArray[A] private (val addr: Addr) extends AnyVal {
   def transform(f: A => A): EmbedArray[A]                     = macro macros.EmbedArrayApi.transform
   def filter(f: A => Boolean)
             (implicit a: Allocator): EmbedArray[A]            = macro macros.EmbedArrayApi.filter
-  def foldLeft[B](z: B, op: (B, A) => B): B                   = macro macros.EmbedArrayApi.foldLeft[B]
-  def foldRight[B](z: B, op: (A, B) => B): B                  = macro macros.EmbedArrayApi.foldRight[B]
+  def foldLeft[B](z: B)(op: (B, A) => B): B                   = macro macros.EmbedArrayApi.foldLeft[B]
+  def foldRight[B](z: B)(op: (A, B) => B): B                  = macro macros.EmbedArrayApi.foldRight[B]
   def forall(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.forall
   def exists(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.exists
   def toArray: scala.Array[A]                                 = macro macros.EmbedArrayApi.toArray

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -33,6 +33,4 @@ x86-64 hardware and recent Linux, Mac OS operating systems. The library
 hasn't been tested on other software/hardware configurations and might
 or might not work for them.
 
-If you've managed to successfully use the library on other environments let us now.
-
-
+If you've managed to successfully use the library on other environments let us know.

--- a/docs/03_off-heap_arrays.md
+++ b/docs/03_off-heap_arrays.md
@@ -24,6 +24,8 @@ stored as `Addr` references.
 * `arr.forall(f)`. Check if given predicate applies to all elements in the array.
 * `arr.exists(f)`. Check if given predicate applies to at least one element in the array.
 * `arr.filter(f)`. Create a new array where each element satifies given predicate.
+* `arr.foldLeft(z, op)`, `arr.foldRight(z, op)`. Applies given operator to a starting value and all elements of 
+  this array going from left or right.
 * `arr.sameElements(other)`. Check if this and given array have the same elements in the same order.
 * `arr.startsWith(that)`. Check if this array starts with the same elements as the given array.
 * `arr.startsWith(that, offset)`. Check if this array starts with the same elements as the given array, 

--- a/docs/03_off-heap_arrays.md
+++ b/docs/03_off-heap_arrays.md
@@ -24,7 +24,7 @@ stored as `Addr` references.
 * `arr.forall(f)`. Check if given predicate applies to all elements in the array.
 * `arr.exists(f)`. Check if given predicate applies to at least one element in the array.
 * `arr.filter(f)`. Create a new array where each element satifies given predicate.
-* `arr.foldLeft(z, op)`, `arr.foldRight(z, op)`. Applies given operator to a starting value and all elements of 
+* `arr.foldLeft(z)(op)`, `arr.foldRight(z)(op)`. Applies given operator to a starting value and all elements of 
   this array going from left or right.
 * `arr.sameElements(other)`. Check if this and given array have the same elements in the same order.
 * `arr.startsWith(that)`. Check if this array starts with the same elements as the given array.

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -49,10 +49,8 @@ trait ArrayCommon extends Common {
   def iterate(pre: Tree, T: Type, f: Tree => Tree) = {
     val i = freshVar("i", IntTpe, q"0")
     val len = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
-    val base = freshVal("base", AddrTpe, q"$pre.addr + $sizeOfHeader")
     q"""
       $len
-      $base
       $i
       while (${i.symbol} < ${len.symbol}) {
         ..${f(q"${i.symbol}")}
@@ -117,8 +115,6 @@ trait ArrayApiCommon extends ArrayCommon {
       stabilized(a) { alloc =>
         val narr = freshVal("narr", appliedType(MyArrayTpe, B),
                             q"$MyArrayModule.uninit[$B]($pre.length)($alloc)")
-        val base = freshVal("base", AddrTpe,
-                            q"${narr.symbol}.addr + $sizeOfHeader")
         val body =
           iterate(pre, A, idx =>
             writeElem(q"${narr.symbol}", B, idx, app(f, readElem(pre, A, idx))))
@@ -126,7 +122,6 @@ trait ArrayApiCommon extends ArrayCommon {
           if ($pre.isEmpty) $MyArrayModule.empty[$B]
           else {
             $narr
-            $base
             ..$body
             ${narr.symbol}
           }

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -248,7 +248,7 @@ trait ArrayApiCommon extends ArrayCommon {
     }
   }
 
-  def foldLeft[B: WeakTypeTag](z: Tree, op: Tree) = {
+  def foldLeft[B: WeakTypeTag](z: Tree)(op: Tree) = {
     stabilized(c.prefix.tree) { pre =>
       stabilized(z) { z =>
         val acc = freshVar("acc", wt[B], z)
@@ -262,7 +262,7 @@ trait ArrayApiCommon extends ArrayCommon {
     }
   }
 
-  def foldRight[B: WeakTypeTag](z: Tree, op: Tree) = {
+  def foldRight[B: WeakTypeTag](z: Tree)(op: Tree) = {
     stabilized(c.prefix.tree) { pre =>
       stabilized(z) { z =>
         val acc = freshVar("acc", wt[B], z)

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -311,7 +311,7 @@ trait Common extends Definitions {
         }
       }
       val argVals = args map (_._1)
-      val argDefs = args map (_._2)
+      val argDefs = args map (_._2) filter { case q"" => false; case _ => true }
 
       val param2Val = params zip (argVals) map { case (param, arg) =>
         (param.symbol, arg)

--- a/macros/src/main/scala/offheap/internal/macros/Common.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Common.scala
@@ -297,32 +297,40 @@ trait Common extends Definitions {
     (sym.isTerm && sym.asTerm.isStable) || sym.attachments.get[SemiStable].nonEmpty
 
   // TODO: handle non-function literal cases
-  def appSubs(f: Tree, argValue: Tree, subs: Tree => Tree) = f match {
-    case q"($param => $body)" =>
-      val q"$_ val $_: $argTpt = $_" = param
+  def app(f: Tree, argValues: Tree*) = f match {
+    case q"(..$params => $body)" =>
       changeOwner(body, f.symbol, enclosingOwner)
-      val (arg, argDef) = argValue match {
-        case rt: RefTree if isSemiStable(rt.symbol) =>
-          (rt, q"")
-        case _ =>
-          val vd = freshVal("arg", argTpt.tpe, argValue)
-          (q"${vd.symbol}", vd)
+      val args = params zip(argValues) map { case (param, argValue) =>
+        val q"$_ val $_: $argTpt = $_" = param
+        argValue match {
+          case rt: RefTree if isSemiStable(rt.symbol) =>
+            (rt, q"")
+          case _ =>
+            val vd = freshVal("arg", argTpt.tpe, argValue)
+            (q"${vd.symbol}", vd)
+        }
       }
+      val argVals = args map (_._1)
+      val argDefs = args map (_._2)
+
+      val param2Val = params zip (argVals) map { case (param, arg) =>
+        (param.symbol, arg)
+      } toMap
+
       val transformedBody = typingTransform(body) { (tree, api) =>
         tree match {
-          case id: Ident if id.symbol == param.symbol =>
-            api.typecheck(subs(q"$arg"))
+          case id: Ident if param2Val.contains(id.symbol) =>
+            val arg = param2Val(id.symbol)
+            api.typecheck(q"$arg")
           case _ =>
             api.default(tree)
         }
       }
-      q"..$argDef; $transformedBody"
-    case _             =>
-      q"$f($argValue)"
-  }
 
-  def app(f: Tree, argValue: Tree) =
-    appSubs(f, argValue, identity)
+      q"..$argDefs; $transformedBody"
+    case _             =>
+      q"$f(..$argValues)"
+  }
 
   def stabilized(tree: Tree)(f: Tree => Tree) = tree match {
     case q"${const: Literal}" =>

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -205,20 +205,20 @@ class ArraySuite extends FunSuite {
 
   test("foldLeft") {
     val arr = Array(1, 2, 3)
-    assert(arr.foldLeft[Int](0, (acc, el) => (acc + el) * el) == 27)
+    assert(arr.foldLeft[Int](0)((acc, el) => (acc + el) * el) == 27)
   }
 
   test("foldLeft empty") {
-    assert(Array.empty[Int].foldLeft[Int](3, (_, _) => 1) == 3)
+    assert(Array.empty[Int].foldLeft[Int](3)((_, _) => 1) == 3)
   }
 
   test("foldRight") {
     val arr = Array(1, 2, 3)
-    assert(arr.foldRight[Int](0, (el, acc) => (acc + el) * el) == 23)
+    assert(arr.foldRight[Int](0)((el, acc) => (acc + el) * el) == 23)
   }
 
   test("foldRight empty") {
-    assert(Array.empty[Int].foldRight[Int](5, (_, _) => 1) == 5)
+    assert(Array.empty[Int].foldRight[Int](5)((_, _) => 1) == 5)
   }
 
   test("forall") {

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -203,6 +203,24 @@ class ArraySuite extends FunSuite {
     assert(Array.empty[Int].filter(_ => false).isEmpty)
   }
 
+  test("foldLeft") {
+    val arr = Array(1, 2, 3)
+    assert(arr.foldLeft[Int](0, (acc, el) => (acc + el) * el) == 27)
+  }
+
+  test("foldLeft empty") {
+    assert(Array.empty[Int].foldLeft[Int](3, (_, _) => 1) == 3)
+  }
+
+  test("foldRight") {
+    val arr = Array(1, 2, 3)
+    assert(arr.foldRight[Int](0, (el, acc) => (acc + el) * el) == 23)
+  }
+
+  test("foldRight empty") {
+    assert(Array.empty[Int].foldRight[Int](5, (_, _) => 1) == 5)
+  }
+
   test("forall") {
     val arr = Array(1, 3, 5, 7)
     assert(arr.forall(_ < 10))

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -144,11 +144,11 @@ class EmbedArraySuite extends FunSuite {
       EPoint(2, 20),
       EPoint(3, 30)
     )
-    assert(arr.foldLeft[Int](0, (acc, el) => (acc + el.x) * el.x) == 27)
+    assert(arr.foldLeft[Int](0)((acc, el) => (acc + el.x) * el.x) == 27)
   }
 
   test("foldLeft empty") {
-    assert(EmbedArray.empty[EPoint].foldLeft[Int](3, (_, _) => 1) == 3)
+    assert(EmbedArray.empty[EPoint].foldLeft[Int](3)((_, _) => 1) == 3)
   }
 
   test("foldRight") {
@@ -157,11 +157,11 @@ class EmbedArraySuite extends FunSuite {
       EPoint(2, 20),
       EPoint(3, 30)
     )
-    assert(arr.foldRight[Int](0, (el, acc) => (acc + el.x) * el.x) == 23)
+    assert(arr.foldRight[Int](0)((el, acc) => (acc + el.x) * el.x) == 23)
   }
 
   test("foldRight empty") {
-    assert(EmbedArray.empty[EPoint].foldRight[Int](5, (_, _) => 1) == 5)
+    assert(EmbedArray.empty[EPoint].foldRight[Int](5)((_, _) => 1) == 5)
   }
 
   test("forall") {

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -138,6 +138,32 @@ class EmbedArraySuite extends FunSuite {
     assert(EmbedArray.empty[EPoint].filter(_ => false).isEmpty)
   }
 
+  test("foldLeft") {
+    val arr = EmbedArray(
+      EPoint(1, 10),
+      EPoint(2, 20),
+      EPoint(3, 30)
+    )
+    assert(arr.foldLeft[Int](0, (acc, el) => (acc + el.x) * el.x) == 27)
+  }
+
+  test("foldLeft empty") {
+    assert(EmbedArray.empty[EPoint].foldLeft[Int](3, (_, _) => 1) == 3)
+  }
+
+  test("foldRight") {
+    val arr = EmbedArray(
+      EPoint(1, 10),
+      EPoint(2, 20),
+      EPoint(3, 30)
+    )
+    assert(arr.foldRight[Int](0, (el, acc) => (acc + el.x) * el.x) == 23)
+  }
+
+  test("foldRight empty") {
+    assert(EmbedArray.empty[EPoint].foldRight[Int](5, (_, _) => 1) == 5)
+  }
+
   test("forall") {
     val arr = EmbedArray(
       EPoint(1, 10),


### PR DESCRIPTION
Implements #79.

Removed subs parameter in Common.app and appSubs methods since it's not used anywhere. Also I modified Common.app implementation to support inlining of multiple arguments in function literals.