### PR TITLE
Add support for Array.reduceLeft and Array.reduceRight

### DIFF
--- a/core/src/main/scala/offheap/Array.scala
+++ b/core/src/main/scala/offheap/Array.scala
@@ -25,6 +25,8 @@ final class Array[A] private (val addr: Addr) extends AnyVal {
             (implicit a: Allocator): Array[A]            = macro macros.ArrayApi.filter
   def foldLeft[B](z: B)(op: (B, A) => B): B              = macro macros.ArrayApi.foldLeft[B]
   def foldRight[B](z: B)(op: (A, B) => B): B             = macro macros.ArrayApi.foldRight[B]
+  def reduceLeft(op: (A, A) => A): A                     = macro macros.ArrayApi.reduceLeft
+  def reduceRight(op: (A, A) => A): A                    = macro macros.ArrayApi.reduceRight
   def forall(f: A => Boolean): Boolean                   = macro macros.ArrayApi.forall
   def exists(f: A => Boolean): Boolean                   = macro macros.ArrayApi.exists
   def sameElements(other: Array[A]): Boolean             = macro macros.ArrayApi.sameElements

--- a/core/src/main/scala/offheap/EmbedArray.scala
+++ b/core/src/main/scala/offheap/EmbedArray.scala
@@ -21,6 +21,8 @@ final class EmbedArray[A] private (val addr: Addr) extends AnyVal {
             (implicit a: Allocator): EmbedArray[A]            = macro macros.EmbedArrayApi.filter
   def foldLeft[B](z: B)(op: (B, A) => B): B                   = macro macros.EmbedArrayApi.foldLeft[B]
   def foldRight[B](z: B)(op: (A, B) => B): B                  = macro macros.EmbedArrayApi.foldRight[B]
+  def reduceLeft(op: (A, A) => A): A                          = macro macros.EmbedArrayApi.reduceLeft
+  def reduceRight(op: (A, A) => A): A                         = macro macros.EmbedArrayApi.reduceRight
   def forall(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.forall
   def exists(f: A => Boolean): Boolean                        = macro macros.EmbedArrayApi.exists
   def toArray: scala.Array[A]                                 = macro macros.EmbedArrayApi.toArray

--- a/docs/03_off-heap_arrays.md
+++ b/docs/03_off-heap_arrays.md
@@ -26,6 +26,8 @@ stored as `Addr` references.
 * `arr.filter(f)`. Create a new array where each element satifies given predicate.
 * `arr.foldLeft(z)(op)`, `arr.foldRight(z)(op)`. Applies given operator to a starting value and all elements of 
   this array going from left or right.
+* `arr.reduceLeft(op)`, `arr.reduceRight(op)`. Applies given operator to all elements of this array going from
+  left or right.
 * `arr.sameElements(other)`. Check if this and given array have the same elements in the same order.
 * `arr.startsWith(that)`. Check if this array starts with the same elements as the given array.
 * `arr.startsWith(that, offset)`. Check if this array starts with the same elements as the given array, 

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -51,7 +51,7 @@ trait ArrayCommon extends Common {
 
   def iterate(pre: Tree, T: Type, f: Tree => Tree) = {
     val i = freshVar("i", IntTpe, q"0")
-    val len = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+    val len = freshVal("len", ArraySizeTpe, readSize(pre))
     q"""
       $len
       $i
@@ -63,7 +63,7 @@ trait ArrayCommon extends Common {
   }
 
   def iterateRight(pre: Tree, T: Type, f: Tree => Tree) = {
-    val len = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+    val len = freshVal("len", ArraySizeTpe, readSize(pre))
     val i = freshVar("i", IntTpe, q"${len.symbol} - 1")
     q"""
       $len
@@ -201,7 +201,7 @@ trait ArrayApiCommon extends ArrayCommon {
         val newArray = freshVal("narr", appliedType(MyArrayTpe, A),
           q"$MyArrayModule.uninit[$A]($pre.length)($alloc)")
 
-        val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+        val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
 
         val sourceIndex = freshVar("i", IntTpe, q"0")
         val newArrayIndex = freshVar("j", IntTpe, q"0")
@@ -283,7 +283,7 @@ trait ArrayApiCommon extends ArrayCommon {
     stabilized(c.prefix.tree) { pre =>
       val acc = freshVar("acc", A, readElem(pre, A, q"0"))
       val sourceIndex = freshVar("i", IntTpe, q"1")
-      val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+      val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
       q"""
         if ($pre.isEmpty) ${throwUnsupportedOperation("empty.reduceLeft")}
         else {
@@ -302,7 +302,7 @@ trait ArrayApiCommon extends ArrayCommon {
 
   def reduceRight(op: Tree) = {
     stabilized(c.prefix.tree) { pre =>
-      val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+      val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
       val acc = freshVar("acc", A, readElem(pre, A, q"${sourceLength.symbol} - 1"))
       val sourceIndex = freshVar("i", IntTpe, q"${sourceLength.symbol} - 2")
       q"""
@@ -324,7 +324,7 @@ trait ArrayApiCommon extends ArrayCommon {
   def forall(f: Tree) =
     stabilized(c.prefix.tree) { pre =>
       val sourceIndex = freshVar("i", IntTpe, q"0")
-      val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+      val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
       val result = freshVar("result", BooleanTpe, q"true")
       q"""
         if ($pre.isEmpty) true
@@ -345,7 +345,7 @@ trait ArrayApiCommon extends ArrayCommon {
   def exists(f: Tree) =
     stabilized(c.prefix.tree) { pre =>
       val sourceIndex = freshVar("i", IntTpe, q"0")
-      val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
+      val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
       val result = freshVar("result", BooleanTpe, q"false")
       q"""
         if ($pre.isEmpty) false
@@ -367,8 +367,8 @@ trait ArrayApiCommon extends ArrayCommon {
     stabilized(c.prefix.tree) { pre =>
       stabilized(other) { oth =>
         val sourceIndex = freshVar("i", IntTpe, q"0")
-        val sourceLength = freshVal("len", ArraySizeTpe, read(q"$pre.addr", ArraySizeTpe))
-        val otherLength = freshVal("othLen", ArraySizeTpe, read(q"$oth.addr", ArraySizeTpe))
+        val sourceLength = freshVal("len", ArraySizeTpe, readSize(pre))
+        val otherLength = freshVal("othLen", ArraySizeTpe, readSize(oth))
         val result = freshVar("result", BooleanTpe, q"true")
         q"""
           if ($pre.addr == $oth.addr) true

--- a/macros/src/main/scala/offheap/internal/macros/Array.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Array.scala
@@ -447,7 +447,7 @@ trait ArrayApiCommon extends ArrayCommon {
             $sourceLength
             $thatLength
             $offset
-            if (${offset.symbol} < 0 || ${offset.symbol} + ${thatLength.symbol} > ${sourceLength.symbol}) false
+            if (${offset.symbol} < 0) false
             else {
               $index
               $result

--- a/macros/src/main/scala/offheap/internal/macros/Definitions.scala
+++ b/macros/src/main/scala/offheap/internal/macros/Definitions.scala
@@ -11,10 +11,11 @@ trait Definitions {
   import c.universe.definitions._
   import c.universe.rootMirror._
 
-  val StringBuilderClass             = staticClass("scala.collection.mutable.StringBuilder")
-  val NullPointerExceptionClass      = staticClass("java.lang.NullPointerException")
-  val IllegalArgumentExceptionClass  = staticClass("java.lang.IllegalArgumentException")
-  val IndexOutOfBoundsExceptionClass = staticClass("java.lang.IndexOutOfBoundsException")
+  val StringBuilderClass                 = staticClass("scala.collection.mutable.StringBuilder")
+  val NullPointerExceptionClass          = staticClass("java.lang.NullPointerException")
+  val IllegalArgumentExceptionClass      = staticClass("java.lang.IllegalArgumentException")
+  val IndexOutOfBoundsExceptionClass     = staticClass("java.lang.IndexOutOfBoundsException")
+  val UnsupportedOperationExceptionClass = staticClass("java.lang.UnsupportedOperationException")
 
   val RegionClass             = staticClass("scala.offheap.Region")
   val PoolRegionClass         = staticClass("scala.offheap.PoolRegion")

--- a/tests/src/test/scala/ArraySuite.scala
+++ b/tests/src/test/scala/ArraySuite.scala
@@ -221,6 +221,30 @@ class ArraySuite extends FunSuite {
     assert(Array.empty[Int].foldRight[Int](5)((_, _) => 1) == 5)
   }
 
+  test("reduceLeft") {
+    val arr = Array(1, 2, 3)
+    assert(arr.reduceLeft((acc, el) => (acc + el) * el) == 27)
+
+    val single = Array(5)
+    assert(single.reduceLeft((_, _) => 1) == 5)
+
+    intercept[UnsupportedOperationException] {
+      Array.empty[Int].reduceLeft { (_, _) => 1 }
+    }
+  }
+
+  test("reduceRight") {
+    val arr = Array(1, 2, 3)
+    assert(arr.reduceRight((el, acc) => (acc + el) * el) == 11)
+
+    val single = Array(5)
+    assert(single.reduceRight((_, _) => 1) == 5)
+
+    intercept[UnsupportedOperationException] {
+      Array.empty[Int].reduceRight { (_, _) => 1 }
+    }
+  }
+
   test("forall") {
     val arr = Array(1, 3, 5, 7)
     assert(arr.forall(_ < 10))

--- a/tests/src/test/scala/EmbedArraySuite.scala
+++ b/tests/src/test/scala/EmbedArraySuite.scala
@@ -164,6 +164,34 @@ class EmbedArraySuite extends FunSuite {
     assert(EmbedArray.empty[EPoint].foldRight[Int](5)((_, _) => 1) == 5)
   }
 
+  test("reduceLeft") {
+    val arr = EmbedArray[EPoint](
+      EPoint(1, 10),
+      EPoint(2, 20),
+      EPoint(3, 30)
+    )
+    val result = arr.reduceLeft { (acc, el) => EPoint((acc.x + el.x) * el.x, acc.y) }
+    assert(result.x == 27)
+
+    intercept[UnsupportedOperationException] {
+      Array.empty[EPoint].reduceLeft { (_, _) => EPoint(0, 0) }
+    }
+  }
+
+  test("reduceRight") {
+    val arr = EmbedArray[EPoint](
+      EPoint(1, 10),
+      EPoint(2, 20),
+      EPoint(3, 30)
+    )
+    val result = arr.reduceRight { (el, acc) => EPoint((acc.x + el.x) * el.x, acc.y) }
+    assert(result.x == 11)
+
+    intercept[UnsupportedOperationException] {
+      Array.empty[EPoint].reduceRight { (_, _) => EPoint(0, 0) }
+    }
+  }
+
   test("forall") {
     val arr = EmbedArray(
       EPoint(1, 10),


### PR DESCRIPTION
Implements #97.

I didn't include the type parameter in the method signature since A is always a value class.